### PR TITLE
OAUTH2-265 Bundled REST applications are missing application name and scope translations

### DIFF
--- a/modules/apps/bulk/bulk-rest-impl/src/main/resources/content/Language.properties
+++ b/modules/apps/bulk/bulk-rest-impl/src/main/resources/content/Language.properties
@@ -1,0 +1,8 @@
+oauth2.application.description.Liferay.Bulk.REST=Bulk Processing
+oauth2.scope.DELETE=create/update/delete data on your behalf
+oauth2.scope.GET=read data on your behalf
+oauth2.scope.HEAD=read data on your behalf
+oauth2.scope.OPTIONS=read data on your behalf
+oauth2.scope.PATCH=create/update/delete data on your behalf
+oauth2.scope.POST=create/update/delete data on your behalf
+oauth2.scope.PUT=create/update/delete data on your behalf

--- a/modules/apps/change-tracking/change-tracking-rest/src/main/java/com/liferay/change/tracking/rest/internal/application/CTJaxRsApplication.java
+++ b/modules/apps/change-tracking/change-tracking-rest/src/main/java/com/liferay/change/tracking/rest/internal/application/CTJaxRsApplication.java
@@ -28,7 +28,7 @@ import org.osgi.service.component.annotations.Component;
 		"osgi.jaxrs.application.base=/change-tracking",
 		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=jaxb-json)",
 		"osgi.jaxrs.extension.select=(osgi.jaxrs.name=Liferay.Vulcan)",
-		"osgi.jaxrs.name=change-tracking-application"
+		"osgi.jaxrs.name=Liferay.Change.Tracking.REST"
 	},
 	service = Application.class
 )

--- a/modules/apps/change-tracking/change-tracking-rest/src/main/java/com/liferay/change/tracking/rest/internal/context/provider/UserContextProvider.java
+++ b/modules/apps/change-tracking/change-tracking-rest/src/main/java/com/liferay/change/tracking/rest/internal/context/provider/UserContextProvider.java
@@ -36,7 +36,7 @@ import org.osgi.service.component.annotations.ServiceScope;
  */
 @Component(
 	property = {
-		"osgi.jaxrs.application.select=(osgi.jaxrs.name=change-tracking-application)",
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Change.Tracking.REST)",
 		"osgi.jaxrs.extension=true", "osgi.jaxrs.name=CTUser"
 	},
 	scope = ServiceScope.PROTOTYPE, service = ContextProvider.class

--- a/modules/apps/change-tracking/change-tracking-rest/src/main/java/com/liferay/change/tracking/rest/internal/exception/mapper/CTApplicationExceptionMapper.java
+++ b/modules/apps/change-tracking/change-tracking-rest/src/main/java/com/liferay/change/tracking/rest/internal/exception/mapper/CTApplicationExceptionMapper.java
@@ -28,7 +28,7 @@ import org.osgi.service.component.annotations.Component;
  */
 @Component(
 	property = {
-		"osgi.jaxrs.application.select=(osgi.jaxrs.name=change-tracking-application)",
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Change.Tracking.REST)",
 		"osgi.jaxrs.extension=true"
 	},
 	service = ExceptionMapper.class

--- a/modules/apps/change-tracking/change-tracking-rest/src/main/java/com/liferay/change/tracking/rest/internal/resource/CTAffectedEntryResource.java
+++ b/modules/apps/change-tracking/change-tracking-rest/src/main/java/com/liferay/change/tracking/rest/internal/resource/CTAffectedEntryResource.java
@@ -39,7 +39,7 @@ import org.osgi.service.component.annotations.ServiceScope;
  */
 @Component(
 	property = {
-		"osgi.jaxrs.application.select=(osgi.jaxrs.name=change-tracking-application)",
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Change.Tracking.REST)",
 		"osgi.jaxrs.resource=true"
 	},
 	scope = ServiceScope.PROTOTYPE, service = CTAffectedEntryResource.class

--- a/modules/apps/change-tracking/change-tracking-rest/src/main/java/com/liferay/change/tracking/rest/internal/resource/CTCollectionResource.java
+++ b/modules/apps/change-tracking/change-tracking-rest/src/main/java/com/liferay/change/tracking/rest/internal/resource/CTCollectionResource.java
@@ -66,7 +66,7 @@ import org.osgi.service.component.annotations.ServiceScope;
  */
 @Component(
 	property = {
-		"osgi.jaxrs.application.select=(osgi.jaxrs.name=change-tracking-application)",
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Change.Tracking.REST)",
 		"osgi.jaxrs.resource=true"
 	},
 	scope = ServiceScope.PROTOTYPE, service = CTCollectionResource.class

--- a/modules/apps/change-tracking/change-tracking-rest/src/main/java/com/liferay/change/tracking/rest/internal/resource/CTConfigurationResource.java
+++ b/modules/apps/change-tracking/change-tracking-rest/src/main/java/com/liferay/change/tracking/rest/internal/resource/CTConfigurationResource.java
@@ -50,7 +50,7 @@ import org.osgi.service.component.annotations.ServiceScope;
  */
 @Component(
 	property = {
-		"osgi.jaxrs.application.select=(osgi.jaxrs.name=change-tracking-application)",
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Change.Tracking.REST)",
 		"osgi.jaxrs.resource=true"
 	},
 	scope = ServiceScope.PROTOTYPE, service = CTConfigurationResource.class

--- a/modules/apps/change-tracking/change-tracking-rest/src/main/java/com/liferay/change/tracking/rest/internal/resource/CTEntryResource.java
+++ b/modules/apps/change-tracking/change-tracking-rest/src/main/java/com/liferay/change/tracking/rest/internal/resource/CTEntryResource.java
@@ -54,7 +54,7 @@ import org.osgi.service.component.annotations.ServiceScope;
  */
 @Component(
 	property = {
-		"osgi.jaxrs.application.select=(osgi.jaxrs.name=change-tracking-application)",
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Change.Tracking.REST)",
 		"osgi.jaxrs.resource=true"
 	},
 	scope = ServiceScope.PROTOTYPE, service = CTEntryResource.class

--- a/modules/apps/change-tracking/change-tracking-rest/src/main/java/com/liferay/change/tracking/rest/internal/resource/CTProcessResource.java
+++ b/modules/apps/change-tracking/change-tracking-rest/src/main/java/com/liferay/change/tracking/rest/internal/resource/CTProcessResource.java
@@ -70,7 +70,7 @@ import org.osgi.service.component.annotations.ServiceScope;
  */
 @Component(
 	property = {
-		"osgi.jaxrs.application.select=(osgi.jaxrs.name=change-tracking-application)",
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Change.Tracking.REST)",
 		"osgi.jaxrs.resource=true"
 	},
 	scope = ServiceScope.PROTOTYPE, service = CTProcessResource.class

--- a/modules/apps/change-tracking/change-tracking-rest/src/main/resources/content/Language.properties
+++ b/modules/apps/change-tracking/change-tracking-rest/src/main/resources/content/Language.properties
@@ -1,0 +1,8 @@
+oauth2.application.description.Liferay.Change.Tracking.REST=Change Tracking
+oauth2.scope.DELETE=create/update/delete data on your behalf
+oauth2.scope.GET=read data on your behalf
+oauth2.scope.HEAD=read data on your behalf
+oauth2.scope.OPTIONS=read data on your behalf
+oauth2.scope.PATCH=create/update/delete data on your behalf
+oauth2.scope.POST=create/update/delete data on your behalf
+oauth2.scope.PUT=create/update/delete data on your behalf

--- a/modules/apps/data-engine/data-engine-rest-impl/src/main/resources/content/Language.properties
+++ b/modules/apps/data-engine/data-engine-rest-impl/src/main/resources/content/Language.properties
@@ -1,0 +1,8 @@
+oauth2.application.description.Liferay.Data.Engine.REST=Dynamic Data Lists
+oauth2.scope.DELETE=create/update/delete data on your behalf
+oauth2.scope.GET=read data on your behalf
+oauth2.scope.HEAD=read data on your behalf
+oauth2.scope.OPTIONS=read data on your behalf
+oauth2.scope.PATCH=create/update/delete data on your behalf
+oauth2.scope.POST=create/update/delete data on your behalf
+oauth2.scope.PUT=create/update/delete data on your behalf

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/resources/content/Language.properties
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/resources/content/Language.properties
@@ -1,0 +1,8 @@
+oauth2.application.description.Liferay.Headless.Admin.Taxonomy=Taxonomy Administration
+oauth2.scope.DELETE=create/update/delete data on your behalf
+oauth2.scope.GET=read data on your behalf
+oauth2.scope.HEAD=read data on your behalf
+oauth2.scope.OPTIONS=read data on your behalf
+oauth2.scope.PATCH=create/update/delete data on your behalf
+oauth2.scope.POST=create/update/delete data on your behalf
+oauth2.scope.PUT=create/update/delete data on your behalf

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/content/Language.properties
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/resources/content/Language.properties
@@ -1,0 +1,8 @@
+oauth2.application.description.Liferay.Headless.Admin.User=Users Administration
+oauth2.scope.DELETE=create/update/delete data on your behalf
+oauth2.scope.GET=read data on your behalf
+oauth2.scope.HEAD=read data on your behalf
+oauth2.scope.OPTIONS=read data on your behalf
+oauth2.scope.PATCH=create/update/delete data on your behalf
+oauth2.scope.POST=create/update/delete data on your behalf
+oauth2.scope.PUT=create/update/delete data on your behalf

--- a/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/resources/content/Language.properties
+++ b/modules/apps/headless/headless-admin-workflow/headless-admin-workflow-impl/src/main/resources/content/Language.properties
@@ -1,0 +1,8 @@
+oauth2.application.description.Liferay.Headless.Admin.Workflow=Workflow Administration
+oauth2.scope.DELETE=create/update/delete data on your behalf
+oauth2.scope.GET=read data on your behalf
+oauth2.scope.HEAD=read data on your behalf
+oauth2.scope.OPTIONS=read data on your behalf
+oauth2.scope.PATCH=create/update/delete data on your behalf
+oauth2.scope.POST=create/update/delete data on your behalf
+oauth2.scope.PUT=create/update/delete data on your behalf

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/content/Language.properties
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/resources/content/Language.properties
@@ -1,0 +1,8 @@
+oauth2.application.description.Liferay.Headless.Delivery=Content Delivery
+oauth2.scope.DELETE=create/update/delete data on your behalf
+oauth2.scope.GET=read data on your behalf
+oauth2.scope.HEAD=read data on your behalf
+oauth2.scope.OPTIONS=read data on your behalf
+oauth2.scope.PATCH=create/update/delete data on your behalf
+oauth2.scope.POST=create/update/delete data on your behalf
+oauth2.scope.PUT=create/update/delete data on your behalf

--- a/modules/apps/headless/headless-form/headless-form-impl/src/main/resources/content/Language.properties
+++ b/modules/apps/headless/headless-form/headless-form-impl/src/main/resources/content/Language.properties
@@ -1,0 +1,8 @@
+oauth2.application.description.Liferay.Headless.Form=Forms
+oauth2.scope.DELETE=create/update/delete data on your behalf
+oauth2.scope.GET=read data on your behalf
+oauth2.scope.HEAD=read data on your behalf
+oauth2.scope.OPTIONS=read data on your behalf
+oauth2.scope.PATCH=create/update/delete data on your behalf
+oauth2.scope.POST=create/update/delete data on your behalf
+oauth2.scope.PUT=create/update/delete data on your behalf


### PR DESCRIPTION
Hi Javier. Here is a complete set of changes needed to provide full OAuth 2 translations for all JAX-RS apps.

3dc1768 & 7f727ec were agreed with @matethurzo (Staging)
ddb3e2d was agreed with @jeyvison (DDL & DDM)

The translations for the scopes match the JSON-WS OAuth 2 scopes for consistent UX.
Because the default OAuth 2 provider configuration groups GET,HEAD,OPTIONS into a "everything.read" scope and PUT/POST/PATCH into a "everything.write" scope, the translations are identical. If you require a different grouping then we must provide ConfigurableScopeMapperConfiguration for specific JAX-RS apps.
