### PR TITLE
LPS-102573 Complete the addition of actions to all entities in APIs

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/bnd.bnd
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Admin Taxonomy API
 Bundle-SymbolicName: com.liferay.headless.admin.taxonomy.api
-Bundle-Version: 4.1.1
+Bundle-Version: 4.2.0
 Export-Package:\
 	com.liferay.headless.admin.taxonomy.dto.v1_0,\
 	com.liferay.headless.admin.taxonomy.resource.v1_0

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/dto/v1_0/Keyword.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/dto/v1_0/Keyword.java
@@ -52,6 +52,36 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlRootElement(name = "Keyword")
 public class Keyword {
 
+	@Schema
+	@Valid
+	public Map<String, Map<String, String>> getActions() {
+		return actions;
+	}
+
+	public void setActions(Map<String, Map<String, String>> actions) {
+		this.actions = actions;
+	}
+
+	@JsonIgnore
+	public void setActions(
+		UnsafeSupplier<Map<String, Map<String, String>>, Exception>
+			actionsUnsafeSupplier) {
+
+		try {
+			actions = actionsUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Map<String, Map<String, String>> actions;
+
 	@Schema(description = "The keyword's creator.")
 	@Valid
 	public Creator getCreator() {
@@ -281,6 +311,16 @@ public class Keyword {
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
 			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		if (actions != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"actions\": ");
+
+			sb.append(_toJSON(actions));
+		}
 
 		if (creator != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/dto/v1_0/TaxonomyCategory.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/dto/v1_0/TaxonomyCategory.java
@@ -88,6 +88,36 @@ public class TaxonomyCategory {
 
 	}
 
+	@Schema
+	@Valid
+	public Map<String, Map<String, String>> getActions() {
+		return actions;
+	}
+
+	public void setActions(Map<String, Map<String, String>> actions) {
+		this.actions = actions;
+	}
+
+	@JsonIgnore
+	public void setActions(
+		UnsafeSupplier<Map<String, Map<String, String>>, Exception>
+			actionsUnsafeSupplier) {
+
+		try {
+			actions = actionsUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Map<String, Map<String, String>> actions;
+
 	@Schema(
 		description = "A list of languages the category has a translation for."
 	)
@@ -550,6 +580,16 @@ public class TaxonomyCategory {
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
 			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		if (actions != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"actions\": ");
+
+			sb.append(_toJSON(actions));
+		}
 
 		if (availableLanguages != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/dto/v1_0/TaxonomyVocabulary.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/dto/v1_0/TaxonomyVocabulary.java
@@ -88,6 +88,36 @@ public class TaxonomyVocabulary {
 
 	}
 
+	@Schema
+	@Valid
+	public Map<String, Map<String, String>> getActions() {
+		return actions;
+	}
+
+	public void setActions(Map<String, Map<String, String>> actions) {
+		this.actions = actions;
+	}
+
+	@JsonIgnore
+	public void setActions(
+		UnsafeSupplier<Map<String, Map<String, String>>, Exception>
+			actionsUnsafeSupplier) {
+
+		try {
+			actions = actionsUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Map<String, Map<String, String>> actions;
+
 	@Schema(
 		description = "A list of asset types that can be associated with this vocabulary."
 	)
@@ -520,6 +550,16 @@ public class TaxonomyVocabulary {
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
 			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		if (actions != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"actions\": ");
+
+			sb.append(_toJSON(actions));
+		}
 
 		if (assetTypes != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/resources/com/liferay/headless/admin/taxonomy/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/resources/com/liferay/headless/admin/taxonomy/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 2.2.0

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/dto/v1_0/Keyword.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/dto/v1_0/Keyword.java
@@ -18,6 +18,7 @@ import com.liferay.headless.admin.taxonomy.client.function.UnsafeSupplier;
 import com.liferay.headless.admin.taxonomy.client.serdes.v1_0.KeywordSerDes;
 
 import java.util.Date;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -28,6 +29,28 @@ import javax.annotation.Generated;
  */
 @Generated("")
 public class Keyword {
+
+	public Map<String, Map<String, String>> getActions() {
+		return actions;
+	}
+
+	public void setActions(Map<String, Map<String, String>> actions) {
+		this.actions = actions;
+	}
+
+	public void setActions(
+		UnsafeSupplier<Map<String, Map<String, String>>, Exception>
+			actionsUnsafeSupplier) {
+
+		try {
+			actions = actionsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Map<String, Map<String, String>> actions;
 
 	public Creator getCreator() {
 		return creator;

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/dto/v1_0/TaxonomyCategory.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/dto/v1_0/TaxonomyCategory.java
@@ -61,6 +61,28 @@ public class TaxonomyCategory {
 
 	}
 
+	public Map<String, Map<String, String>> getActions() {
+		return actions;
+	}
+
+	public void setActions(Map<String, Map<String, String>> actions) {
+		this.actions = actions;
+	}
+
+	public void setActions(
+		UnsafeSupplier<Map<String, Map<String, String>>, Exception>
+			actionsUnsafeSupplier) {
+
+		try {
+			actions = actionsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Map<String, Map<String, String>> actions;
+
 	public String[] getAvailableLanguages() {
 		return availableLanguages;
 	}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/dto/v1_0/TaxonomyVocabulary.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/dto/v1_0/TaxonomyVocabulary.java
@@ -61,6 +61,28 @@ public class TaxonomyVocabulary {
 
 	}
 
+	public Map<String, Map<String, String>> getActions() {
+		return actions;
+	}
+
+	public void setActions(Map<String, Map<String, String>> actions) {
+		this.actions = actions;
+	}
+
+	public void setActions(
+		UnsafeSupplier<Map<String, Map<String, String>>, Exception>
+			actionsUnsafeSupplier) {
+
+		try {
+			actions = actionsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Map<String, Map<String, String>> actions;
+
 	public AssetType[] getAssetTypes() {
 		return assetTypes;
 	}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/serdes/v1_0/KeywordSerDes.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/serdes/v1_0/KeywordSerDes.java
@@ -59,6 +59,16 @@ public class KeywordSerDes {
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
 			"yyyy-MM-dd'T'HH:mm:ss'Z'");
 
+		if (keyword.getActions() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"actions\": ");
+
+			sb.append(_toJSON(keyword.getActions()));
+		}
+
 		if (keyword.getCreator() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -163,6 +173,13 @@ public class KeywordSerDes {
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
 			"yyyy-MM-dd'T'HH:mm:ss'Z'");
 
+		if (keyword.getActions() == null) {
+			map.put("actions", null);
+		}
+		else {
+			map.put("actions", String.valueOf(keyword.getActions()));
+		}
+
 		if (keyword.getCreator() == null) {
 			map.put("creator", null);
 		}
@@ -228,7 +245,13 @@ public class KeywordSerDes {
 			Keyword keyword, String jsonParserFieldName,
 			Object jsonParserFieldValue) {
 
-			if (Objects.equals(jsonParserFieldName, "creator")) {
+			if (Objects.equals(jsonParserFieldName, "actions")) {
+				if (jsonParserFieldValue != null) {
+					keyword.setActions(
+						(Map)KeywordSerDes.toMap((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "creator")) {
 				if (jsonParserFieldValue != null) {
 					keyword.setCreator(
 						CreatorSerDes.toDTO((String)jsonParserFieldValue));

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/serdes/v1_0/TaxonomyCategorySerDes.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/serdes/v1_0/TaxonomyCategorySerDes.java
@@ -61,6 +61,16 @@ public class TaxonomyCategorySerDes {
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
 			"yyyy-MM-dd'T'HH:mm:ss'Z'");
 
+		if (taxonomyCategory.getActions() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"actions\": ");
+
+			sb.append(_toJSON(taxonomyCategory.getActions()));
+		}
+
 		if (taxonomyCategory.getAvailableLanguages() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -273,6 +283,13 @@ public class TaxonomyCategorySerDes {
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
 			"yyyy-MM-dd'T'HH:mm:ss'Z'");
 
+		if (taxonomyCategory.getActions() == null) {
+			map.put("actions", null);
+		}
+		else {
+			map.put("actions", String.valueOf(taxonomyCategory.getActions()));
+		}
+
 		if (taxonomyCategory.getAvailableLanguages() == null) {
 			map.put("availableLanguages", null);
 		}
@@ -403,7 +420,16 @@ public class TaxonomyCategorySerDes {
 			TaxonomyCategory taxonomyCategory, String jsonParserFieldName,
 			Object jsonParserFieldValue) {
 
-			if (Objects.equals(jsonParserFieldName, "availableLanguages")) {
+			if (Objects.equals(jsonParserFieldName, "actions")) {
+				if (jsonParserFieldValue != null) {
+					taxonomyCategory.setActions(
+						(Map)TaxonomyCategorySerDes.toMap(
+							(String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "availableLanguages")) {
+
 				if (jsonParserFieldValue != null) {
 					taxonomyCategory.setAvailableLanguages(
 						toStrings((Object[])jsonParserFieldValue));

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/serdes/v1_0/TaxonomyVocabularySerDes.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/serdes/v1_0/TaxonomyVocabularySerDes.java
@@ -63,6 +63,16 @@ public class TaxonomyVocabularySerDes {
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
 			"yyyy-MM-dd'T'HH:mm:ss'Z'");
 
+		if (taxonomyVocabulary.getActions() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"actions\": ");
+
+			sb.append(_toJSON(taxonomyVocabulary.getActions()));
+		}
+
 		if (taxonomyVocabulary.getAssetTypes() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -273,6 +283,13 @@ public class TaxonomyVocabularySerDes {
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
 			"yyyy-MM-dd'T'HH:mm:ss'Z'");
 
+		if (taxonomyVocabulary.getActions() == null) {
+			map.put("actions", null);
+		}
+		else {
+			map.put("actions", String.valueOf(taxonomyVocabulary.getActions()));
+		}
+
 		if (taxonomyVocabulary.getAssetTypes() == null) {
 			map.put("assetTypes", null);
 		}
@@ -395,7 +412,14 @@ public class TaxonomyVocabularySerDes {
 			TaxonomyVocabulary taxonomyVocabulary, String jsonParserFieldName,
 			Object jsonParserFieldValue) {
 
-			if (Objects.equals(jsonParserFieldName, "assetTypes")) {
+			if (Objects.equals(jsonParserFieldName, "actions")) {
+				if (jsonParserFieldValue != null) {
+					taxonomyVocabulary.setActions(
+						(Map)TaxonomyVocabularySerDes.toMap(
+							(String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "assetTypes")) {
 				if (jsonParserFieldValue != null) {
 					taxonomyVocabulary.setAssetTypes(
 						Stream.of(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-openapi.yaml
@@ -72,6 +72,13 @@ components:
                 Represents a keyword that describes content. Properties follow the
                 [keywords](https://schema.org/keywords) specification.
             properties:
+                actions:
+                    additionalProperties:
+                        additionalProperties:
+                            type: string
+                        type: object
+                    readOnly: true
+                    type: object
                 creator:
                     allOf:
                         - $ref: "#/components/schemas/Creator"
@@ -119,6 +126,13 @@ components:
                 Represents a category, which is a hierarchical classification that can be associated with particular
                 asset types. Properties follow the [category](https://schema.org/category) specification.
             properties:
+                actions:
+                    additionalProperties:
+                        additionalProperties:
+                            type: string
+                        type: object
+                    readOnly: true
+                    type: object
                 availableLanguages:
                     description:
                         A list of languages the category has a translation for.
@@ -208,6 +222,13 @@ components:
                 Represents a vocabulary, which is a grouping of categories for a specific purpose (e.g., classification,
                 sorting, etc.).
             properties:
+                actions:
+                    additionalProperties:
+                        additionalProperties:
+                            type: string
+                        type: object
+                    readOnly: true
+                    type: object
                 assetTypes:
                     description:
                         A list of asset types that can be associated with this vocabulary.

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/graphql/query/v1_0/Query.java
@@ -79,7 +79,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {keyword(keywordId: ___){creator, dateCreated, dateModified, id, keywordUsageCount, name, siteId}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {keyword(keywordId: ___){actions, creator, dateCreated, dateModified, id, keywordUsageCount, name, siteId}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(description = "Retrieves a keyword.")
 	public Keyword keyword(@GraphQLName("keywordId") Long keywordId)
@@ -154,7 +154,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {taxonomyCategory(taxonomyCategoryId: ___){availableLanguages, creator, dateCreated, dateModified, description, description_i18n, externalReferenceCode, id, name, name_i18n, numberOfTaxonomyCategories, parentTaxonomyCategory, parentTaxonomyVocabulary, viewableBy}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {taxonomyCategory(taxonomyCategoryId: ___){actions, availableLanguages, creator, dateCreated, dateModified, description, description_i18n, externalReferenceCode, id, name, name_i18n, numberOfTaxonomyCategories, parentTaxonomyCategory, parentTaxonomyVocabulary, viewableBy}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(description = "Retrieves a taxonomy category.")
 	public TaxonomyCategory taxonomyCategory(
@@ -233,7 +233,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {taxonomyVocabulary(taxonomyVocabularyId: ___){assetTypes, availableLanguages, creator, dateCreated, dateModified, description, description_i18n, id, name, name_i18n, numberOfTaxonomyCategories, siteId, viewableBy}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {taxonomyVocabulary(taxonomyVocabularyId: ___){actions, assetTypes, availableLanguages, creator, dateCreated, dateModified, description, description_i18n, id, name, name_i18n, numberOfTaxonomyCategories, siteId, viewableBy}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(description = "Retrieves a taxonomy vocabulary.")
 	public TaxonomyVocabulary taxonomyVocabulary(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyCategoryResourceImpl.java
@@ -204,6 +204,10 @@ public abstract class BaseTaxonomyCategoryResourceImpl
 		TaxonomyCategory existingTaxonomyCategory = getTaxonomyCategory(
 			taxonomyCategoryId);
 
+		if (taxonomyCategory.getActions() != null) {
+			existingTaxonomyCategory.setActions(taxonomyCategory.getActions());
+		}
+
 		if (taxonomyCategory.getAvailableLanguages() != null) {
 			existingTaxonomyCategory.setAvailableLanguages(
 				taxonomyCategory.getAvailableLanguages());

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/BaseTaxonomyVocabularyResourceImpl.java
@@ -200,6 +200,11 @@ public abstract class BaseTaxonomyVocabularyResourceImpl
 		TaxonomyVocabulary existingTaxonomyVocabulary = getTaxonomyVocabulary(
 			taxonomyVocabularyId);
 
+		if (taxonomyVocabulary.getActions() != null) {
+			existingTaxonomyVocabulary.setActions(
+				taxonomyVocabulary.getActions());
+		}
+
 		if (taxonomyVocabulary.getAvailableLanguages() != null) {
 			existingTaxonomyVocabulary.setAvailableLanguages(
 				taxonomyVocabulary.getAvailableLanguages());

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/KeywordResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/KeywordResourceImpl.java
@@ -28,6 +28,7 @@ import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -36,7 +37,7 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.SearchUtil;
 
-import java.util.Collections;
+import java.util.Map;
 
 import javax.ws.rs.core.MultivaluedMap;
 
@@ -76,7 +77,7 @@ public class KeywordResourceImpl
 		throws Exception {
 
 		return SearchUtil.search(
-			Collections.emptyMap(),
+			_getSiteListActions(siteId),
 			booleanQuery -> {
 			},
 			filter, AssetTag.class, search, pagination,
@@ -109,9 +110,43 @@ public class KeywordResourceImpl
 			_assetTagService.updateTag(keywordId, keyword.getName(), null));
 	}
 
+	private Map<String, Map<String, String>> _getActions(AssetTag assetTag) {
+		return HashMapBuilder.<String, Map<String, String>>put(
+			"delete",
+			addAction(
+				"MANAGE_TAG", assetTag.getTagId(), "deleteKeyword",
+				"com.liferay.asset.tags", assetTag.getGroupId())
+		).put(
+			"get",
+			addAction(
+				"MANAGE_TAG", assetTag.getTagId(), "getKeyword",
+				"com.liferay.asset.tags", assetTag.getGroupId())
+		).put(
+			"replace",
+			addAction(
+				"MANAGE_TAG", assetTag.getTagId(), "putKeyword",
+				"com.liferay.asset.tags", assetTag.getGroupId())
+		).build();
+	}
+
+	private Map<String, Map<String, String>> _getSiteListActions(Long siteId) {
+		return HashMapBuilder.<String, Map<String, String>>put(
+			"create",
+			addAction(
+				"MANAGE_TAG", "postSiteKeyword", "com.liferay.asset.tags",
+				siteId)
+		).put(
+			"get",
+			addAction(
+				"MANAGE_TAG", "getSiteKeywordsPage", "com.liferay.asset.tags",
+				siteId)
+		).build();
+	}
+
 	private Keyword _toKeyword(AssetTag assetTag) {
 		return new Keyword() {
 			{
+				actions = _getActions(assetTag);
 				dateCreated = assetTag.getCreateDate();
 				dateModified = assetTag.getModifiedDate();
 				id = assetTag.getTagId();

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyVocabularyResourceImpl.java
@@ -104,7 +104,7 @@ public class TaxonomyVocabularyResourceImpl
 		throws Exception {
 
 		return SearchUtil.search(
-			Collections.emptyMap(),
+			_getSiteListActions(siteId),
 			booleanQuery -> {
 			},
 			filter, AssetVocabulary.class, search, pagination,
@@ -240,6 +240,23 @@ public class TaxonomyVocabularyResourceImpl
 					taxonomyVocabulary.getAssetTypes(),
 					assetVocabulary.getGroupId()),
 				new ServiceContext()));
+	}
+
+	private Map<String, Map<String, String>> _getActions(
+		AssetVocabulary assetVocabulary) {
+
+		return HashMapBuilder.<String, Map<String, String>>put(
+			"delete",
+			addAction("DELETE", assetVocabulary, "deleteTaxonomyVocabulary")
+		).put(
+			"get", addAction("VIEW", assetVocabulary, "getTaxonomyVocabulary")
+		).put(
+			"replace",
+			addAction("UPDATE", assetVocabulary, "putTaxonomyVocabulary")
+		).put(
+			"update",
+			addAction("UPDATE", assetVocabulary, "patchTaxonomyVocabulary")
+		).build();
 	}
 
 	private AssetType _getAssetType(
@@ -472,12 +489,27 @@ public class TaxonomyVocabularyResourceImpl
 		return assetVocabularySettingsHelper.toString();
 	}
 
+	private Map<String, Map<String, String>> _getSiteListActions(Long siteId) {
+		return HashMapBuilder.<String, Map<String, String>>put(
+			"create",
+			addAction(
+				"ADD_VOCABULARY", "postSiteTaxonomyVocabulary",
+				"com.liferay.asset.categories", siteId)
+		).put(
+			"get",
+			addAction(
+				"VIEW", "getSiteTaxonomyVocabulariesPage",
+				"com.liferay.asset.categories", siteId)
+		).build();
+	}
+
 	private TaxonomyVocabulary _toTaxonomyVocabulary(
 			AssetVocabulary assetVocabulary)
 		throws Exception {
 
 		return new TaxonomyVocabulary() {
 			{
+				actions = _getActions(assetVocabulary);
 				assetTypes = _getAssetTypes(
 					new AssetVocabularySettingsHelper(
 						assetVocabulary.getSettings()),

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseKeywordResourceTestCase.java
@@ -872,6 +872,14 @@ public abstract class BaseKeywordResourceTestCase {
 		for (String additionalAssertFieldName :
 				getAdditionalAssertFieldNames()) {
 
+			if (Objects.equals("actions", additionalAssertFieldName)) {
+				if (keyword.getActions() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("creator", additionalAssertFieldName)) {
 				if (keyword.getCreator() == null) {
 					valid = false;
@@ -954,6 +962,16 @@ public abstract class BaseKeywordResourceTestCase {
 
 		for (String additionalAssertFieldName :
 				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("actions", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						keyword1.getActions(), keyword2.getActions())) {
+
+					return false;
+				}
+
+				continue;
+			}
 
 			if (Objects.equals("creator", additionalAssertFieldName)) {
 				if (!Objects.deepEquals(
@@ -1114,6 +1132,11 @@ public abstract class BaseKeywordResourceTestCase {
 		sb.append(" ");
 		sb.append(operator);
 		sb.append(" ");
+
+		if (entityFieldName.equals("actions")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
 
 		if (entityFieldName.equals("creator")) {
 			throw new IllegalArgumentException(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
@@ -1199,6 +1199,14 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		for (String additionalAssertFieldName :
 				getAdditionalAssertFieldNames()) {
 
+			if (Objects.equals("actions", additionalAssertFieldName)) {
+				if (taxonomyCategory.getActions() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals(
 					"availableLanguages", additionalAssertFieldName)) {
 
@@ -1353,6 +1361,17 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 
 		for (String additionalAssertFieldName :
 				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("actions", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						taxonomyCategory1.getActions(),
+						taxonomyCategory2.getActions())) {
+
+					return false;
+				}
+
+				continue;
+			}
 
 			if (Objects.equals(
 					"availableLanguages", additionalAssertFieldName)) {
@@ -1640,6 +1659,11 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		sb.append(" ");
 		sb.append(operator);
 		sb.append(" ");
+
+		if (entityFieldName.equals("actions")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
 
 		if (entityFieldName.equals("availableLanguages")) {
 			throw new IllegalArgumentException(

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
@@ -1046,6 +1046,14 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		for (String additionalAssertFieldName :
 				getAdditionalAssertFieldNames()) {
 
+			if (Objects.equals("actions", additionalAssertFieldName)) {
+				if (taxonomyVocabulary.getActions() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("assetTypes", additionalAssertFieldName)) {
 				if (taxonomyVocabulary.getAssetTypes() == null) {
 					valid = false;
@@ -1187,6 +1195,17 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 
 		for (String additionalAssertFieldName :
 				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("actions", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						taxonomyVocabulary1.getActions(),
+						taxonomyVocabulary2.getActions())) {
+
+					return false;
+				}
+
+				continue;
+			}
 
 			if (Objects.equals("assetTypes", additionalAssertFieldName)) {
 				if (!Objects.deepEquals(
@@ -1436,6 +1455,11 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		sb.append(" ");
 		sb.append(operator);
 		sb.append(" ");
+
+		if (entityFieldName.equals("actions")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
 
 		if (entityFieldName.equals("assetTypes")) {
 			throw new IllegalArgumentException(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/bnd.bnd
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Admin User API
 Bundle-SymbolicName: com.liferay.headless.admin.user.api
-Bundle-Version: 13.1.1
+Bundle-Version: 13.2.0
 Export-Package:\
 	com.liferay.headless.admin.user.dto.v1_0,\
 	com.liferay.headless.admin.user.resource.v1_0

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/Organization.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/Organization.java
@@ -50,6 +50,36 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlRootElement(name = "Organization")
 public class Organization {
 
+	@Schema
+	@Valid
+	public Map<String, Map<String, String>> getActions() {
+		return actions;
+	}
+
+	public void setActions(Map<String, Map<String, String>> actions) {
+		this.actions = actions;
+	}
+
+	@JsonIgnore
+	public void setActions(
+		UnsafeSupplier<Map<String, Map<String, String>>, Exception>
+			actionsUnsafeSupplier) {
+
+		try {
+			actions = actionsUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Map<String, Map<String, String>> actions;
+
 	@Schema(
 		description = "The text of a comment associated with the organization."
 	)
@@ -476,6 +506,16 @@ public class Organization {
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
 			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		if (actions != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"actions\": ");
+
+			sb.append(_toJSON(actions));
+		}
 
 		if (comment != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/UserAccount.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/dto/v1_0/UserAccount.java
@@ -50,6 +50,36 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlRootElement(name = "UserAccount")
 public class UserAccount {
 
+	@Schema
+	@Valid
+	public Map<String, Map<String, String>> getActions() {
+		return actions;
+	}
+
+	public void setActions(Map<String, Map<String, String>> actions) {
+		this.actions = actions;
+	}
+
+	@JsonIgnore
+	public void setActions(
+		UnsafeSupplier<Map<String, Map<String, String>>, Exception>
+			actionsUnsafeSupplier) {
+
+		try {
+			actions = actionsUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Map<String, Map<String, String>> actions;
+
 	@Schema(description = "The user's additional name (e.g., middle name).")
 	public String getAdditionalName() {
 		return additionalName;
@@ -709,6 +739,16 @@ public class UserAccount {
 
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
 			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		if (actions != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"actions\": ");
+
+			sb.append(_toJSON(actions));
+		}
 
 		if (additionalName != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/resources/com/liferay/headless/admin/user/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/resources/com/liferay/headless/admin/user/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 5.1.1
+version 5.2.0

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/dto/v1_0/Organization.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/dto/v1_0/Organization.java
@@ -18,6 +18,7 @@ import com.liferay.headless.admin.user.client.function.UnsafeSupplier;
 import com.liferay.headless.admin.user.client.serdes.v1_0.OrganizationSerDes;
 
 import java.util.Date;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -28,6 +29,28 @@ import javax.annotation.Generated;
  */
 @Generated("")
 public class Organization {
+
+	public Map<String, Map<String, String>> getActions() {
+		return actions;
+	}
+
+	public void setActions(Map<String, Map<String, String>> actions) {
+		this.actions = actions;
+	}
+
+	public void setActions(
+		UnsafeSupplier<Map<String, Map<String, String>>, Exception>
+			actionsUnsafeSupplier) {
+
+		try {
+			actions = actionsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Map<String, Map<String, String>> actions;
 
 	public String getComment() {
 		return comment;

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/dto/v1_0/UserAccount.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/dto/v1_0/UserAccount.java
@@ -18,6 +18,7 @@ import com.liferay.headless.admin.user.client.function.UnsafeSupplier;
 import com.liferay.headless.admin.user.client.serdes.v1_0.UserAccountSerDes;
 
 import java.util.Date;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -28,6 +29,28 @@ import javax.annotation.Generated;
  */
 @Generated("")
 public class UserAccount {
+
+	public Map<String, Map<String, String>> getActions() {
+		return actions;
+	}
+
+	public void setActions(Map<String, Map<String, String>> actions) {
+		this.actions = actions;
+	}
+
+	public void setActions(
+		UnsafeSupplier<Map<String, Map<String, String>>, Exception>
+			actionsUnsafeSupplier) {
+
+		try {
+			actions = actionsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Map<String, Map<String, String>> actions;
 
 	public String getAdditionalName() {
 		return additionalName;

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/OrganizationSerDes.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/OrganizationSerDes.java
@@ -64,6 +64,16 @@ public class OrganizationSerDes {
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
 			"yyyy-MM-dd'T'HH:mm:ss'Z'");
 
+		if (organization.getActions() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"actions\": ");
+
+			sb.append(_toJSON(organization.getActions()));
+		}
+
 		if (organization.getComment() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -278,6 +288,13 @@ public class OrganizationSerDes {
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
 			"yyyy-MM-dd'T'HH:mm:ss'Z'");
 
+		if (organization.getActions() == null) {
+			map.put("actions", null);
+		}
+		else {
+			map.put("actions", String.valueOf(organization.getActions()));
+		}
+
 		if (organization.getComment() == null) {
 			map.put("comment", null);
 		}
@@ -392,7 +409,14 @@ public class OrganizationSerDes {
 			Organization organization, String jsonParserFieldName,
 			Object jsonParserFieldValue) {
 
-			if (Objects.equals(jsonParserFieldName, "comment")) {
+			if (Objects.equals(jsonParserFieldName, "actions")) {
+				if (jsonParserFieldValue != null) {
+					organization.setActions(
+						(Map)OrganizationSerDes.toMap(
+							(String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "comment")) {
 				if (jsonParserFieldValue != null) {
 					organization.setComment((String)jsonParserFieldValue);
 				}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/UserAccountSerDes.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/serdes/v1_0/UserAccountSerDes.java
@@ -66,6 +66,16 @@ public class UserAccountSerDes {
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
 			"yyyy-MM-dd'T'HH:mm:ss'Z'");
 
+		if (userAccount.getActions() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"actions\": ");
+
+			sb.append(_toJSON(userAccount.getActions()));
+		}
+
 		if (userAccount.getAdditionalName() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -429,6 +439,13 @@ public class UserAccountSerDes {
 		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
 			"yyyy-MM-dd'T'HH:mm:ss'Z'");
 
+		if (userAccount.getActions() == null) {
+			map.put("actions", null);
+		}
+		else {
+			map.put("actions", String.valueOf(userAccount.getActions()));
+		}
+
 		if (userAccount.getAdditionalName() == null) {
 			map.put("additionalName", null);
 		}
@@ -610,7 +627,14 @@ public class UserAccountSerDes {
 			UserAccount userAccount, String jsonParserFieldName,
 			Object jsonParserFieldValue) {
 
-			if (Objects.equals(jsonParserFieldName, "additionalName")) {
+			if (Objects.equals(jsonParserFieldName, "actions")) {
+				if (jsonParserFieldValue != null) {
+					userAccount.setActions(
+						(Map)UserAccountSerDes.toMap(
+							(String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "additionalName")) {
 				if (jsonParserFieldValue != null) {
 					userAccount.setAdditionalName((String)jsonParserFieldValue);
 				}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
@@ -120,6 +120,13 @@ components:
                 Represents an organization. Organizations can contain other organizations (suborganizations). Properties
                 follow the [Organization](https://schema.org/Organization) specification.
             properties:
+                actions:
+                    additionalProperties:
+                        additionalProperties:
+                            type: string
+                        type: object
+                    readOnly: true
+                    type: object
                 comment:
                     description:
                         The text of a comment associated with the organization.
@@ -602,6 +609,13 @@ components:
             description:
                 Represents a user.
             properties:
+                actions:
+                    additionalProperties:
+                        additionalProperties:
+                            type: string
+                        type: object
+                    readOnly: true
+                    type: object
                 additionalName:
                     description:
                         The user's additional name (e.g., middle name).

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/helper/OrganizationResourceDTOConverter.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/helper/OrganizationResourceDTOConverter.java
@@ -110,6 +110,7 @@ public class OrganizationResourceDTOConverter
 
 		return new Organization() {
 			{
+				actions = dtoConverterContext.getActions();
 				comment = organization.getComments();
 				customFields = CustomFieldsUtil.toCustomFields(
 					dtoConverterContext.isAcceptAllLanguages(),

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/query/v1_0/Query.java
@@ -241,7 +241,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {organization(organizationId: ___){comment, customFields, dateCreated, dateModified, id, image, keywords, location, name, numberOfOrganizations, organizationContactInformation, parentOrganization, services}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {organization(organizationId: ___){actions, comment, customFields, dateCreated, dateModified, id, image, keywords, location, name, numberOfOrganizations, organizationContactInformation, parentOrganization, services}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(description = "Retrieves the organization.")
 	public Organization organization(
@@ -573,7 +573,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {myUserAccount{additionalName, alternateName, birthDate, customFields, dashboardURL, dateCreated, dateModified, emailAddress, familyName, givenName, honorificPrefix, honorificSuffix, id, image, jobTitle, keywords, name, organizationBriefs, profileURL, roleBriefs, siteBriefs, userAccountContactInformation}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {myUserAccount{actions, additionalName, alternateName, birthDate, customFields, dashboardURL, dateCreated, dateModified, emailAddress, familyName, givenName, honorificPrefix, honorificSuffix, id, image, jobTitle, keywords, name, organizationBriefs, profileURL, roleBriefs, siteBriefs, userAccountContactInformation}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(
 		description = "Retrieves information about the user who made the request."
@@ -671,7 +671,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {userAccount(userAccountId: ___){additionalName, alternateName, birthDate, customFields, dashboardURL, dateCreated, dateModified, emailAddress, familyName, givenName, honorificPrefix, honorificSuffix, id, image, jobTitle, keywords, name, organizationBriefs, profileURL, roleBriefs, siteBriefs, userAccountContactInformation}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {userAccount(userAccountId: ___){actions, additionalName, alternateName, birthDate, customFields, dashboardURL, dateCreated, dateModified, emailAddress, familyName, givenName, honorificPrefix, honorificSuffix, id, image, jobTitle, keywords, name, organizationBriefs, profileURL, roleBriefs, siteBriefs, userAccountContactInformation}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(description = "Retrieves the user account.")
 	public UserAccount userAccount(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseOrganizationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseOrganizationResourceImpl.java
@@ -188,6 +188,10 @@ public abstract class BaseOrganizationResourceImpl
 
 		Organization existingOrganization = getOrganization(organizationId);
 
+		if (organization.getActions() != null) {
+			existingOrganization.setActions(organization.getActions());
+		}
+
 		if (organization.getComment() != null) {
 			existingOrganization.setComment(organization.getComment());
 		}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OrganizationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OrganizationResourceImpl.java
@@ -368,12 +368,12 @@ public class OrganizationResourceImpl
 	}
 
 	private Page<Organization> _getOrganizationsPage(
-			Map<String, Map<String, String>> actions, String organizationId,
+			Map<String, Map<String, String>> actions, String parentOrganizationId,
 			Boolean flatten, String search, Filter filter,
 			Pagination pagination, Sort[] sorts)
 		throws Exception {
 
-		long id = _getOrganizationId(organizationId);
+		long id = _getOrganizationId(parentOrganizationId);
 
 		return SearchUtil.search(
 			actions,
@@ -386,11 +386,11 @@ public class OrganizationResourceImpl
 						booleanFilter.add(
 							new QueryFilter(
 								new WildcardQueryImpl(
-									"treePath", "*" + organizationId + "*")));
+									"treePath", "*" + parentOrganizationId + "*")));
 						booleanFilter.add(
 							new TermFilter(
 								"organizationId",
-								String.valueOf(organizationId)),
+								String.valueOf(parentOrganizationId)),
 							BooleanClauseOccur.MUST_NOT);
 					}
 				}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/UserAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/UserAccountResourceImpl.java
@@ -59,6 +59,7 @@ import com.liferay.portal.kernel.service.RoleService;
 import com.liferay.portal.kernel.service.UserService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.odata.entity.EntityModel;
@@ -69,6 +70,7 @@ import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 import com.liferay.portal.vulcan.util.SearchUtil;
 
 import java.util.Collections;
+import java.util.Map;
 
 import javax.ws.rs.core.MultivaluedMap;
 
@@ -110,6 +112,7 @@ public class UserAccountResourceImpl
 			organizationId);
 
 		return _getUserAccountsPage(
+			_getOrganizationListActions(organization),
 			booleanQuery -> {
 				BooleanFilter booleanFilter =
 					booleanQuery.getPreBooleanFilter();
@@ -130,6 +133,7 @@ public class UserAccountResourceImpl
 		throws Exception {
 
 		return _getUserAccountsPage(
+			_getSiteListActions(siteId),
 			booleanQuery -> {
 				BooleanFilter booleanFilter =
 					booleanQuery.getPreBooleanFilter();
@@ -159,6 +163,7 @@ public class UserAccountResourceImpl
 		}
 
 		return _getUserAccountsPage(
+			Collections.emptyMap(),
 			booleanQuery -> {
 				BooleanFilter booleanFilter =
 					booleanQuery.getPreBooleanFilter();
@@ -168,6 +173,15 @@ public class UserAccountResourceImpl
 					BooleanClauseOccur.MUST_NOT);
 			},
 			search, filter, pagination, sorts);
+	}
+
+	private Map<String, Map<String, String>> _getActions(User user) {
+		return HashMapBuilder.<String, Map<String, String>>put(
+			"get",
+			addAction(
+				"VIEW", user.getUserId(), "getUserAccount",
+				User.class.getName(), user.getGroupId())
+		).build();
 	}
 
 	private String _getListTypeMessage(long listTypeId) throws Exception {
@@ -181,6 +195,26 @@ public class UserAccountResourceImpl
 			contextAcceptLanguage.getPreferredLocale(), listType.getName());
 	}
 
+	private Map<String, Map<String, String>> _getOrganizationListActions(
+		Organization organization) {
+
+		return HashMapBuilder.<String, Map<String, String>>put(
+			"get",
+			addAction(
+				"VIEW", organization.getOrganizationId(),
+				"getOrganizationUserAccountsPage", Organization.class.getName(),
+				organization.getGroupId())
+		).build();
+	}
+
+	private Map<String, Map<String, String>> _getSiteListActions(Long siteId) {
+		return HashMapBuilder.<String, Map<String, String>>put(
+			"get",
+			addAction(
+				"VIEW", "getSiteUserAccountsPage", User.class.getName(), siteId)
+		).build();
+	}
+
 	private ThemeDisplay _getThemeDisplay(Group group) {
 		return new ThemeDisplay() {
 			{
@@ -191,13 +225,14 @@ public class UserAccountResourceImpl
 	}
 
 	private Page<UserAccount> _getUserAccountsPage(
+			Map<String, Map<String, String>> actions,
 			UnsafeConsumer<BooleanQuery, Exception> booleanQueryUnsafeConsumer,
 			String search, Filter filter, Pagination pagination, Sort[] sorts)
 		throws Exception {
 
 		return SearchUtil.search(
-			Collections.emptyMap(), booleanQueryUnsafeConsumer, filter,
-			User.class, search, pagination,
+			actions, booleanQueryUnsafeConsumer, filter, User.class, search,
+			pagination,
 			queryConfig -> queryConfig.setSelectedFieldNames(
 				Field.ENTRY_CLASS_PK),
 			searchContext -> searchContext.setCompanyId(
@@ -248,6 +283,7 @@ public class UserAccountResourceImpl
 
 		return new UserAccount() {
 			{
+				actions = _getActions(user);
 				additionalName = user.getMiddleName();
 				alternateName = user.getScreenName();
 				birthDate = user.getBirthday();

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseOrganizationResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseOrganizationResourceTestCase.java
@@ -1081,6 +1081,14 @@ public abstract class BaseOrganizationResourceTestCase {
 		for (String additionalAssertFieldName :
 				getAdditionalAssertFieldNames()) {
 
+			if (Objects.equals("actions", additionalAssertFieldName)) {
+				if (organization.getActions() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("comment", additionalAssertFieldName)) {
 				if (organization.getComment() == null) {
 					valid = false;
@@ -1222,6 +1230,17 @@ public abstract class BaseOrganizationResourceTestCase {
 
 		for (String additionalAssertFieldName :
 				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("actions", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						organization1.getActions(),
+						organization2.getActions())) {
+
+					return false;
+				}
+
+				continue;
+			}
 
 			if (Objects.equals("comment", additionalAssertFieldName)) {
 				if (!Objects.deepEquals(
@@ -1491,6 +1510,11 @@ public abstract class BaseOrganizationResourceTestCase {
 		sb.append(" ");
 		sb.append(operator);
 		sb.append(" ");
+
+		if (entityFieldName.equals("actions")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
 
 		if (entityFieldName.equals("comment")) {
 			sb.append("'");

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountResourceTestCase.java
@@ -1219,6 +1219,14 @@ public abstract class BaseUserAccountResourceTestCase {
 		for (String additionalAssertFieldName :
 				getAdditionalAssertFieldNames()) {
 
+			if (Objects.equals("actions", additionalAssertFieldName)) {
+				if (userAccount.getActions() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("additionalName", additionalAssertFieldName)) {
 				if (userAccount.getAdditionalName() == null) {
 					valid = false;
@@ -1430,6 +1438,16 @@ public abstract class BaseUserAccountResourceTestCase {
 
 		for (String additionalAssertFieldName :
 				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("actions", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						userAccount1.getActions(), userAccount2.getActions())) {
+
+					return false;
+				}
+
+				continue;
+			}
 
 			if (Objects.equals("additionalName", additionalAssertFieldName)) {
 				if (!Objects.deepEquals(
@@ -1884,6 +1902,11 @@ public abstract class BaseUserAccountResourceTestCase {
 		sb.append(" ");
 		sb.append(operator);
 		sb.append(" ");
+
+		if (entityFieldName.equals("actions")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
 
 		if (entityFieldName.equals("additionalName")) {
 			sb.append("'");

--- a/modules/apps/headless/headless-common-spi/src/main/java/com/liferay/headless/common/spi/resource/SPICommentResource.java
+++ b/modules/apps/headless/headless-common-spi/src/main/java/com/liferay/headless/common/spi/resource/SPICommentResource.java
@@ -47,6 +47,7 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.util.SearchUtil;
 
 import java.util.Collections;
+import java.util.Map;
 import java.util.function.Function;
 
 import javax.ws.rs.ClientErrorException;
@@ -92,12 +93,31 @@ public class SPICommentResource<T> {
 			Sort[] sorts)
 		throws Exception {
 
-		return _getComments(commentId, search, filter, pagination, sorts);
+		return _getComments(
+			Collections.emptyMap(), commentId, search, filter, pagination,
+			sorts);
 	}
 
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getEntityCommentsPage(Map, long, String, long, String,
+	 *             Filter, Pagination, Sort[])}
+	 */
+	@Deprecated
 	public Page<T> getEntityCommentsPage(
 			long groupId, String className, long classPK, String search,
 			Filter filter, Pagination pagination, Sort[] sorts)
+		throws Exception {
+
+		return getEntityCommentsPage(
+			Collections.emptyMap(), groupId, className, classPK, search, filter,
+			pagination, sorts);
+	}
+
+	public Page<T> getEntityCommentsPage(
+			Map<String, Map<String, String>> actions, long groupId,
+			String className, long classPK, String search, Filter filter,
+			Pagination pagination, Sort[] sorts)
 		throws Exception {
 
 		Discussion discussion = _commentManager.getDiscussion(
@@ -108,8 +128,8 @@ public class SPICommentResource<T> {
 			discussion.getRootDiscussionComment();
 
 		return _getComments(
-			rootDiscussionComment.getCommentId(), search, filter, pagination,
-			sorts);
+			actions, rootDiscussionComment.getCommentId(), search, filter,
+			pagination, sorts);
 	}
 
 	public EntityModel getEntityModel(MultivaluedMap multivaluedMap) {
@@ -184,19 +204,19 @@ public class SPICommentResource<T> {
 	}
 
 	private Page<T> _getComments(
-			Long parentCommentId, String search, Filter filter,
-			Pagination pagination, Sort[] sorts)
+			Map<String, Map<String, String>> actions, Long commentId,
+			String search, Filter filter, Pagination pagination, Sort[] sorts)
 		throws Exception {
 
 		return SearchUtil.search(
-			Collections.emptyMap(),
+			actions,
 			booleanQuery -> {
 				BooleanFilter booleanFilter =
 					booleanQuery.getPreBooleanFilter();
 
 				booleanFilter.add(
 					new TermFilter(
-						"parentMessageId", String.valueOf(parentCommentId)),
+						"parentMessageId", String.valueOf(commentId)),
 					BooleanClauseOccur.MUST);
 			},
 			filter, MBMessage.class, search, pagination,

--- a/modules/apps/headless/headless-common-spi/src/main/resources/com/liferay/headless/common/spi/resource/packageinfo
+++ b/modules/apps/headless/headless-common-spi/src/main/resources/com/liferay/headless/common/spi/resource/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/util/RatingUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/util/RatingUtil.java
@@ -19,17 +19,19 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.ratings.kernel.model.RatingsEntry;
 
+import java.util.Map;
+
 /**
  * @author Javier Gamarra
  */
 public class RatingUtil {
 
 	public static Rating toRating(
-			Portal portal, RatingsEntry ratingsEntry,
-			UserLocalService userLocalService)
+			Map<String, Map<String, String>> actions, Portal portal,
+			RatingsEntry ratingsEntry, UserLocalService userLocalService)
 		throws Exception {
 
-		return new Rating() {
+		Rating rating = new Rating() {
 			{
 				bestRating = 1D;
 				creator = CreatorUtil.toCreator(
@@ -41,6 +43,10 @@ public class RatingUtil {
 				worstRating = 0D;
 			}
 		};
+
+		rating.setActions(actions);
+
+		return rating;
 	}
 
 }

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BlogPostingResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BlogPostingResourceImpl.java
@@ -50,6 +50,7 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.LocalDateTimeUtil;
 import com.liferay.portal.vulcan.util.SearchUtil;
+import com.liferay.ratings.kernel.model.RatingsEntry;
 import com.liferay.ratings.kernel.service.RatingsEntryLocalService;
 
 import java.io.Serializable;
@@ -312,18 +313,39 @@ public class BlogPostingResourceImpl
 		).build();
 	}
 
+	private Map<String, Map<String, String>> _getRatingActions(
+			RatingsEntry ratingsEntry)
+		throws Exception {
+
+		BlogsEntry blogsEntry = _blogsEntryService.getEntry(
+			ratingsEntry.getClassPK());
+
+		return HashMapBuilder.<String, Map<String, String>>put(
+			"create", addAction("UPDATE", blogsEntry, "postBlogPostingMyRating")
+		).put(
+			"delete",
+			addAction("UPDATE", blogsEntry, "deleteBlogPostingMyRating")
+		).put(
+			"get", addAction("VIEW", blogsEntry, "getBlogPostingMyRating")
+		).put(
+			"replace", addAction("UPDATE", blogsEntry, "putBlogPostingMyRating")
+		).build();
+	}
+
 	private SPIRatingResource<Rating> _getSPIRatingResource() {
 		return new SPIRatingResource<>(
 			BlogsEntry.class.getName(), _ratingsEntryLocalService,
 			ratingsEntry -> RatingUtil.toRating(
-				_portal, ratingsEntry, _userLocalService),
+				_getRatingActions(ratingsEntry), _portal, ratingsEntry,
+				_userLocalService),
 			contextUser);
 	}
 
 	private BlogPosting _toBlogPosting(BlogsEntry blogsEntry) throws Exception {
 		return _blogPostingDTOConverter.toDTO(
 			new DefaultDTOConverterContext(
-				false, _getActions(blogsEntry), _dtoConverterRegistry,
+				contextAcceptLanguage.isAcceptAllLanguages(),
+				_getActions(blogsEntry), _dtoConverterRegistry,
 				blogsEntry.getEntryId(),
 				contextAcceptLanguage.getPreferredLocale(), contextUriInfo,
 				contextUser));

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/CommentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/CommentResourceImpl.java
@@ -27,11 +27,14 @@ import com.liferay.journal.service.JournalArticleService;
 import com.liferay.portal.kernel.comment.CommentManager;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
+
+import java.util.Map;
 
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.MultivaluedMap;
@@ -70,6 +73,9 @@ public class CommentResourceImpl
 		BlogsEntry blogsEntry = _blogsEntryService.getEntry(blogPostingId);
 
 		return spiCommentResource.getEntityCommentsPage(
+			_getBlogPostingCommentsListActions(
+				BlogsEntry.class.getName(), blogPostingId,
+				blogsEntry.getGroupId()),
 			blogsEntry.getGroupId(), BlogsEntry.class.getName(), blogPostingId,
 			search, filter, pagination, sorts);
 	}
@@ -107,6 +113,9 @@ public class CommentResourceImpl
 		DLFileEntry dlFileEntry = _dlFileEntryService.getFileEntry(documentId);
 
 		return spiCommentResource.getEntityCommentsPage(
+			_getDocumentCommentsListActions(
+				DLFileEntry.class.getName(), documentId,
+				dlFileEntry.getGroupId()),
 			dlFileEntry.getGroupId(), DLFileEntry.class.getName(), documentId,
 			search, filter, pagination, sorts);
 	}
@@ -132,6 +141,9 @@ public class CommentResourceImpl
 			structuredContentId);
 
 		return spiCommentResource.getEntityCommentsPage(
+			_getStructuredContentCommentsListActions(
+				JournalArticle.class.getName(), structuredContentId,
+				journalArticle.getGroupId()),
 			journalArticle.getGroupId(), JournalArticle.class.getName(),
 			structuredContentId, search, filter, pagination, sorts);
 	}
@@ -208,11 +220,59 @@ public class CommentResourceImpl
 		return spiCommentResource.putComment(commentId, comment.getText());
 	}
 
+	private Map<String, Map<String, String>> _getBlogPostingCommentsListActions(
+		String className, Long entityId, long groupId) {
+
+		return HashMapBuilder.<String, Map<String, String>>put(
+			"add-discussion",
+			addAction(
+				"ADD_DISCUSSION", entityId, "postBlogPostingComment", className,
+				groupId)
+		).put(
+			"get",
+			addAction(
+				"VIEW", entityId, "getBlogPostingCommentsPage", className,
+				groupId)
+		).build();
+	}
+
+	private Map<String, Map<String, String>> _getDocumentCommentsListActions(
+		String className, Long entityId, long groupId) {
+
+		return HashMapBuilder.<String, Map<String, String>>put(
+			"add-discussion",
+			addAction(
+				"ADD_DISCUSSION", entityId, "postDocumentComment", className,
+				groupId)
+		).put(
+			"get",
+			addAction(
+				"VIEW", entityId, "getDocumentCommentsPage", className, groupId)
+		).build();
+	}
+
 	private SPICommentResource<Comment> _getSPICommentResource() {
 		return new SPICommentResource<>(
 			_commentManager, contextCompany,
 			comment -> CommentUtil.toComment(
 				comment, _commentManager, _portal));
+	}
+
+	private Map<String, Map<String, String>>
+		_getStructuredContentCommentsListActions(
+			String className, Long entityId, long groupId) {
+
+		return HashMapBuilder.<String, Map<String, String>>put(
+			"add-discussion",
+			addAction(
+				"ADD_DISCUSSION", entityId, "postStructuredContentComment",
+				className, groupId)
+		).put(
+			"get",
+			addAction(
+				"VIEW", entityId, "getStructuredContentCommentsPage", className,
+				groupId)
+		).build();
 	}
 
 	@Reference

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentFolderResourceImpl.java
@@ -87,8 +87,10 @@ public class DocumentFolderResourceImpl
 
 		return _getDocumentFoldersPage(
 			_getDocumentFolderListActions(parentDocumentFolder.getSiteId()),
-			parentDocumentFolder.getSiteId(), flatten, search, filter,
-			parentDocumentFolder.getId(), pagination, sorts);
+			parentDocumentFolder.getId(), parentDocumentFolder.getSiteId(),
+			flatten,
+			search, filter, pagination,
+			sorts);
 	}
 
 	@Override
@@ -113,8 +115,8 @@ public class DocumentFolderResourceImpl
 		}
 
 		return _getDocumentFoldersPage(
-			_getSiteListActions(siteId), siteId, flatten, search, filter,
-			documentFolderId, pagination, sorts);
+			_getSiteListActions(siteId), documentFolderId, siteId, flatten,
+			search, filter, pagination, sorts);
 	}
 
 	@Override
@@ -264,9 +266,9 @@ public class DocumentFolderResourceImpl
 	}
 
 	private Page<DocumentFolder> _getDocumentFoldersPage(
-			Map<String, Map<String, String>> actions, Long siteId,
-			Boolean flatten, String search, Filter filter,
-			Long parentDocumentFolderId, Pagination pagination, Sort[] sorts)
+		Map<String, Map<String, String>> actions, Long parentDocumentFolderId,
+		Long siteId, Boolean flatten, String search, Filter filter,
+		Pagination pagination, Sort[] sorts)
 		throws Exception {
 
 		return SearchUtil.search(
@@ -287,8 +289,8 @@ public class DocumentFolderResourceImpl
 					}
 
 					booleanFilter.add(
-						new TermFilter(
-							field, String.valueOf(parentDocumentFolderId)),
+						new TermFilter(field, String.valueOf(
+							parentDocumentFolderId)),
 						BooleanClauseOccur.MUST);
 				}
 			},

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/DocumentResourceImpl.java
@@ -57,6 +57,7 @@ import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.SearchUtil;
+import com.liferay.ratings.kernel.model.RatingsEntry;
 import com.liferay.ratings.kernel.service.RatingsEntryLocalService;
 
 import java.io.Serializable;
@@ -467,6 +468,40 @@ public class DocumentResourceImpl
 			contextAcceptLanguage.getPreferredLocale());
 	}
 
+	private Map<String, Map<String, String>> _getRatingActions(
+			RatingsEntry ratingsEntry)
+		throws Exception {
+
+		FileEntry fileEntry = _dlAppService.getFileEntry(
+			ratingsEntry.getClassPK());
+
+		return HashMapBuilder.<String, Map<String, String>>put(
+			"create",
+			addAction(
+				"UPDATE", fileEntry.getPrimaryKey(), "postDocumentMyRating",
+				"com.liferay.document.library.kernel.model.DLFileEntry",
+				fileEntry.getGroupId())
+		).put(
+			"delete",
+			addAction(
+				"UPDATE", fileEntry.getPrimaryKey(), "deleteDocumentMyRating",
+				"com.liferay.document.library.kernel.model.DLFileEntry",
+				fileEntry.getGroupId())
+		).put(
+			"get",
+			addAction(
+				"VIEW", fileEntry.getPrimaryKey(), "getDocumentMyRating",
+				"com.liferay.document.library.kernel.model.DLFileEntry",
+				fileEntry.getGroupId())
+		).put(
+			"replace",
+			addAction(
+				"UPDATE", fileEntry.getPrimaryKey(), "putDocumentMyRating",
+				"com.liferay.document.library.kernel.model.DLFileEntry",
+				fileEntry.getGroupId())
+		).build();
+	}
+
 	private Map<String, Map<String, String>> _getSiteListActions(Long siteId) {
 		return HashMapBuilder.<String, Map<String, String>>put(
 			"create",
@@ -485,7 +520,8 @@ public class DocumentResourceImpl
 		return new SPIRatingResource<>(
 			DLFileEntry.class.getName(), _ratingsEntryLocalService,
 			ratingsEntry -> RatingUtil.toRating(
-				_portal, ratingsEntry, _userLocalService),
+				_getRatingActions(ratingsEntry), _portal, ratingsEntry,
+				_userLocalService),
 			contextUser);
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/KnowledgeBaseArticleResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/KnowledgeBaseArticleResourceImpl.java
@@ -51,6 +51,7 @@ import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.SearchUtil;
+import com.liferay.ratings.kernel.model.RatingsEntry;
 import com.liferay.ratings.kernel.service.RatingsEntryLocalService;
 
 import java.io.Serializable;
@@ -453,6 +454,44 @@ public class KnowledgeBaseArticleResourceImpl
 		).build();
 	}
 
+	private Map<String, Map<String, String>> _getRatingActions(
+			RatingsEntry ratingsEntry)
+		throws Exception {
+
+		KBArticle kbArticle = _kbArticleService.getLatestKBArticle(
+			ratingsEntry.getClassPK(), WorkflowConstants.STATUS_APPROVED);
+
+		return HashMapBuilder.<String, Map<String, String>>put(
+			"create",
+			addAction(
+				"UPDATE", kbArticle.getResourcePrimKey(),
+				"postKnowledgeBaseArticleMyRating",
+				"com.liferay.knowledge.base.model.KBArticle",
+				kbArticle.getGroupId())
+		).put(
+			"delete",
+			addAction(
+				"UPDATE", kbArticle.getResourcePrimKey(),
+				"deleteKnowledgeBaseArticleMyRating",
+				"com.liferay.knowledge.base.model.KBArticle",
+				kbArticle.getGroupId())
+		).put(
+			"get",
+			addAction(
+				"VIEW", kbArticle.getResourcePrimKey(),
+				"getKnowledgeBaseArticleMyRating",
+				"com.liferay.knowledge.base.model.KBArticle",
+				kbArticle.getGroupId())
+		).put(
+			"replace",
+			addAction(
+				"UPDATE", kbArticle.getResourcePrimKey(),
+				"putKnowledgeBaseArticleMyRating",
+				"com.liferay.knowledge.base.model.KBArticle",
+				kbArticle.getGroupId())
+		).build();
+	}
+
 	private Map<String, Map<String, String>> _getSiteListActions(Long siteId) {
 		return HashMapBuilder.<String, Map<String, String>>put(
 			"create",
@@ -481,7 +520,8 @@ public class KnowledgeBaseArticleResourceImpl
 		return new SPIRatingResource<>(
 			KBArticle.class.getName(), _ratingsEntryLocalService,
 			ratingsEntry -> RatingUtil.toRating(
-				_portal, ratingsEntry, _userLocalService),
+				_getRatingActions(ratingsEntry), _portal, ratingsEntry,
+				_userLocalService),
 			contextUser);
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardMessageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardMessageResourceImpl.java
@@ -31,7 +31,6 @@ import com.liferay.message.boards.model.MBMessage;
 import com.liferay.message.boards.model.MBThread;
 import com.liferay.message.boards.service.MBMessageService;
 import com.liferay.message.boards.service.MBThreadLocalService;
-import com.liferay.portal.kernel.model.GroupedModel;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Sort;
@@ -49,6 +48,7 @@ import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.SearchUtil;
+import com.liferay.ratings.kernel.model.RatingsEntry;
 import com.liferay.ratings.kernel.service.RatingsEntryLocalService;
 
 import java.io.Serializable;
@@ -287,34 +287,28 @@ public class MessageBoardMessageResourceImpl
 		return _toMessageBoardMessage(mbMessage);
 	}
 
-	private Map<String, Map<String, String>> _getActions(
-		GroupedModel groupedModel) {
-
+	private Map<String, Map<String, String>> _getActions(MBMessage mbMessage) {
 		return HashMapBuilder.<String, Map<String, String>>put(
 			"delete",
-			addAction("DELETE", groupedModel, "deleteMessageBoardMessage")
+			addAction("DELETE", mbMessage, "deleteMessageBoardMessage")
 		).put(
-			"get", addAction("VIEW", groupedModel, "getMessageBoardMessage")
+			"get", addAction("VIEW", mbMessage, "getMessageBoardMessage")
 		).put(
-			"replace",
-			addAction("UPDATE", groupedModel, "putMessageBoardMessage")
+			"replace", addAction("UPDATE", mbMessage, "putMessageBoardMessage")
 		).put(
 			"reply-to-message",
 			addAction(
-				"REPLY_TO_MESSAGE",
+				"REPLY_TO_MESSAGE", mbMessage.getMessageId(),
 				"postMessageBoardMessageMessageBoardMessage",
-				"com.liferay.message.boards", groupedModel.getGroupId())
+				"com.liferay.message.boards", mbMessage.getGroupId())
 		).put(
 			"subscribe",
-			addAction(
-				"SUBSCRIBE", groupedModel, "putMessageBoardMessageSubscribe")
+			addAction("SUBSCRIBE", mbMessage, "putMessageBoardMessageSubscribe")
 		).put(
 			"unsubscribe",
-			addAction(
-				"SUBSCRIBE", groupedModel, "putMessageBoardMessageSubscribe")
+			addAction("SUBSCRIBE", mbMessage, "putMessageBoardMessageSubscribe")
 		).put(
-			"update",
-			addAction("UPDATE", groupedModel, "patchMessageBoardMessage")
+			"update", addAction("UPDATE", mbMessage, "patchMessageBoardMessage")
 		).build();
 	}
 
@@ -427,6 +421,28 @@ public class MessageBoardMessageResourceImpl
 		).build();
 	}
 
+	private Map<String, Map<String, String>> _getRatingActions(
+			RatingsEntry ratingsEntry)
+		throws Exception {
+
+		MBMessage mbMessage = _mbMessageService.getMessage(
+			ratingsEntry.getClassPK());
+
+		return HashMapBuilder.<String, Map<String, String>>put(
+			"create",
+			addAction("UPDATE", mbMessage, "postMessageBoardMessageMyRating")
+		).put(
+			"delete",
+			addAction("UPDATE", mbMessage, "deleteMessageBoardMessageMyRating")
+		).put(
+			"get",
+			addAction("VIEW", mbMessage, "getMessageBoardMessageMyRating")
+		).put(
+			"replace",
+			addAction("UPDATE", mbMessage, "putMessageBoardMessageMyRating")
+		).build();
+	}
+
 	private Map<String, Map<String, String>> _getSiteListActions(long site) {
 		return HashMapBuilder.<String, Map<String, String>>put(
 			"get",
@@ -440,7 +456,8 @@ public class MessageBoardMessageResourceImpl
 		return new SPIRatingResource<>(
 			MBMessage.class.getName(), _ratingsEntryLocalService,
 			ratingsEntry -> RatingUtil.toRating(
-				_portal, ratingsEntry, _userLocalService),
+				_getRatingActions(ratingsEntry), _portal, ratingsEntry,
+				_userLocalService),
 			contextUser);
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardMessageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardMessageResourceImpl.java
@@ -119,7 +119,7 @@ public class MessageBoardMessageResourceImpl
 
 		return _getMessageBoardMessagesPage(
 			_getMessageBoardListActions(mbMessage), parentMessageBoardMessageId,
-			search, filter, pagination, sorts, flatten, null);
+			null, flatten, search, filter, pagination, sorts);
 	}
 
 	@Override
@@ -143,8 +143,8 @@ public class MessageBoardMessageResourceImpl
 
 		return _getMessageBoardMessagesPage(
 			_getMessageBoardThreadListActions(mbThread),
-			mbThread.getRootMessageId(), search, filter, pagination, sorts,
-			false, null);
+			mbThread.getRootMessageId(), null, false, search, filter,
+			pagination, sorts);
 	}
 
 	@Override
@@ -154,8 +154,8 @@ public class MessageBoardMessageResourceImpl
 		throws Exception {
 
 		return _getMessageBoardMessagesPage(
-			_getSiteListActions(siteId), null, search, filter, pagination,
-			sorts, flatten, siteId);
+			_getSiteListActions(siteId), null, siteId, flatten, search, filter,
+			pagination, sorts);
 	}
 
 	@Override
@@ -340,9 +340,9 @@ public class MessageBoardMessageResourceImpl
 	}
 
 	private Page<MessageBoardMessage> _getMessageBoardMessagesPage(
-			Map<String, Map<String, String>> actions,
-			Long messageBoardMessageId, String search, Filter filter,
-			Pagination pagination, Sort[] sorts, Boolean flatten, Long siteId)
+		Map<String, Map<String, String>> actions,
+		Long messageBoardMessageId, Long siteId, Boolean flatten,
+		String search, Filter filter, Pagination pagination, Sort[] sorts)
 		throws Exception {
 
 		if (messageBoardMessageId != null) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardSectionResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardSectionResourceImpl.java
@@ -222,7 +222,8 @@ public class MessageBoardSectionResourceImpl
 		return HashMapBuilder.<String, Map<String, String>>put(
 			"create",
 			addAction(
-				"ADD_CATEGORY", "postMessageBoardSectionMessageBoardSection",
+				"ADD_CATEGORY", mbCategory.getCategoryId(),
+				"postMessageBoardSectionMessageBoardSection",
 				"com.liferay.message.boards", mbCategory.getGroupId())
 		).put(
 			"delete",

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardThreadResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/MessageBoardThreadResourceImpl.java
@@ -71,6 +71,7 @@ import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.SearchUtil;
+import com.liferay.ratings.kernel.model.RatingsEntry;
 import com.liferay.ratings.kernel.model.RatingsStats;
 import com.liferay.ratings.kernel.service.RatingsEntryLocalService;
 import com.liferay.ratings.kernel.service.RatingsStatsLocalService;
@@ -430,6 +431,27 @@ public class MessageBoardThreadResourceImpl
 		).build();
 	}
 
+	private Map<String, Map<String, String>> _getRatingActions(
+			RatingsEntry ratingsEntry)
+		throws Exception {
+
+		MBMessage mbMessage = _mbMessageService.getMessage(
+			ratingsEntry.getClassPK());
+
+		return HashMapBuilder.<String, Map<String, String>>put(
+			"create",
+			addAction("UPDATE", mbMessage, "postMessageBoardThreadMyRating")
+		).put(
+			"delete",
+			addAction("UPDATE", mbMessage, "deleteMessageBoardThreadMyRating")
+		).put(
+			"get", addAction("VIEW", mbMessage, "getMessageBoardThreadMyRating")
+		).put(
+			"replace",
+			addAction("UPDATE", mbMessage, "putMessageBoardThreadMyRating")
+		).build();
+	}
+
 	private Map<String, Map<String, String>> _getSiteListActions(long groupId) {
 		return HashMapBuilder.<String, Map<String, String>>put(
 			"create",
@@ -470,7 +492,8 @@ public class MessageBoardThreadResourceImpl
 		return new SPIRatingResource<>(
 			MBMessage.class.getName(), _ratingsEntryLocalService,
 			ratingsEntry -> RatingUtil.toRating(
-				_portal, ratingsEntry, _userLocalService),
+				_getRatingActions(ratingsEntry), _portal, ratingsEntry,
+				_userLocalService),
 			contextUser);
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentFolderResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentFolderResourceImpl.java
@@ -95,8 +95,8 @@ public class StructuredContentFolderResourceImpl
 		}
 
 		return _getFoldersPage(
-			_getSiteListActions(siteId), siteId,
-			parentStructuredContentFolderId, search, filter, pagination, sorts);
+			_getSiteListActions(siteId), parentStructuredContentFolderId,
+			siteId, search, filter, pagination, sorts);
 	}
 
 	@Override
@@ -120,7 +120,7 @@ public class StructuredContentFolderResourceImpl
 
 		return _getFoldersPage(
 			_getStructuredContentFolderListActions(journalFolder),
-			journalFolder.getGroupId(), parentStructuredContentFolderId, search,
+			parentStructuredContentFolderId, journalFolder.getGroupId(), search,
 			filter, pagination, sorts);
 	}
 
@@ -248,9 +248,9 @@ public class StructuredContentFolderResourceImpl
 	}
 
 	private Page<StructuredContentFolder> _getFoldersPage(
-			Map<String, Map<String, String>> actions, Long siteId,
-			Long parentStructuredContentFolderId, String search, Filter filter,
-			Pagination pagination, Sort[] sorts)
+			Map<String, Map<String, String>> actions,
+			Long parentStructuredContentFolderId, Long siteId, String search,
+			Filter filter, Pagination pagination, Sort[] sorts)
 		throws Exception {
 
 		return SearchUtil.search(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
@@ -95,6 +95,7 @@ import com.liferay.portal.vulcan.util.ContentLanguageUtil;
 import com.liferay.portal.vulcan.util.LocalDateTimeUtil;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 import com.liferay.portal.vulcan.util.SearchUtil;
+import com.liferay.ratings.kernel.model.RatingsEntry;
 import com.liferay.ratings.kernel.service.RatingsEntryLocalService;
 
 import java.io.Serializable;
@@ -753,6 +754,40 @@ public class StructuredContentResourceImpl
 			contextAcceptLanguage.getPreferredLocale());
 	}
 
+	private Map<String, Map<String, String>> _getRatingActions(
+			RatingsEntry ratingsEntry)
+		throws Exception {
+
+		JournalArticle journalArticle = _journalArticleService.getLatestArticle(
+			ratingsEntry.getClassPK());
+
+		return HashMapBuilder.<String, Map<String, String>>put(
+			"create",
+			addAction(
+				"UPDATE", journalArticle.getResourcePrimKey(),
+				"postStructuredContentMyRating", JournalArticle.class.getName(),
+				journalArticle.getGroupId())
+		).put(
+			"delete",
+			addAction(
+				"UPDATE", journalArticle.getResourcePrimKey(),
+				"deleteStructuredContentMyRating",
+				JournalArticle.class.getName(), journalArticle.getGroupId())
+		).put(
+			"get",
+			addAction(
+				"VIEW", journalArticle.getResourcePrimKey(),
+				"getStructuredContentMyRating", JournalArticle.class.getName(),
+				journalArticle.getGroupId())
+		).put(
+			"replace",
+			addAction(
+				"UPDATE", journalArticle.getResourcePrimKey(),
+				"putStructuredContentMyRating", JournalArticle.class.getName(),
+				journalArticle.getGroupId())
+		).build();
+	}
+
 	private List<DDMFormField> _getRootDDMFormFields(
 		DDMStructure ddmStructure) {
 
@@ -779,7 +814,8 @@ public class StructuredContentResourceImpl
 		return new SPIRatingResource<>(
 			JournalArticle.class.getName(), _ratingsEntryLocalService,
 			ratingsEntry -> RatingUtil.toRating(
-				_portal, ratingsEntry, _userLocalService),
+				_getRatingActions(ratingsEntry), _portal, ratingsEntry,
+				_userLocalService),
 			contextUser);
 	}
 


### PR DESCRIPTION
Add actions to Comments and Ratings in Headless Delivery and to Admin User and Admin Taxonomy entities taking in consideration:

1. Every PortalException has been replaced with Exception in *ResourceImpl classes.

2. With the changes in the REST Builder code generation we avoid the need to cast the actions Map.

3. get*Page method parameters order
To be consistent with the get*Page method parameters order we follow the convention enforced by the REST Builder code generation. This convention is:

- pathParameters
- queryParameters
- Special Objects as filter, pagination and sort (in this order)

Private methods will follow the same convention because they are delegatees of the public method to avoid code duplication and add some extra parameters, and reordering would feel unnatural. Actions is included as the first parameter following the alphabetical order