### PR TITLE
LPS-107895 Fix bug showing wrong number of elements of ContentSet when an element is deleted directly

### DIFF
--- a/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/service/AssetListEntryAssetEntryRelLocalService.java
+++ b/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/service/AssetListEntryAssetEntryRelLocalService.java
@@ -321,6 +321,10 @@ public interface AssetListEntryAssetEntryRelLocalService
 		long assetListEntryId, long segmentsEntryId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int getAssetListEntryVisibleAssetEntryRelsCount(
+		long assetLIstEntryId, long segmentsEntryId);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ExportActionableDynamicQuery getExportActionableDynamicQuery(
 		PortletDataContext portletDataContext);
 

--- a/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/service/AssetListEntryAssetEntryRelLocalServiceUtil.java
+++ b/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/service/AssetListEntryAssetEntryRelLocalServiceUtil.java
@@ -399,6 +399,13 @@ public class AssetListEntryAssetEntryRelLocalServiceUtil {
 			assetListEntryId, segmentsEntryId);
 	}
 
+	public static int getAssetListEntryVisibleAssetEntryRelsCount(
+		long assetLIstEntryId, long segmentsEntryId) {
+
+		return getService().getAssetListEntryVisibleAssetEntryRelsCount(
+			assetLIstEntryId, segmentsEntryId);
+	}
+
 	public static com.liferay.portal.kernel.dao.orm.ExportActionableDynamicQuery
 		getExportActionableDynamicQuery(
 			com.liferay.exportimport.kernel.lar.PortletDataContext

--- a/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/service/AssetListEntryAssetEntryRelLocalServiceWrapper.java
+++ b/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/service/AssetListEntryAssetEntryRelLocalServiceWrapper.java
@@ -426,6 +426,15 @@ public class AssetListEntryAssetEntryRelLocalServiceWrapper
 	}
 
 	@Override
+	public int getAssetListEntryVisibleAssetEntryRelsCount(
+		long assetLIstEntryId, long segmentsEntryId) {
+
+		return _assetListEntryAssetEntryRelLocalService.
+			getAssetListEntryVisibleAssetEntryRelsCount(
+				assetLIstEntryId, segmentsEntryId);
+	}
+
+	@Override
 	public com.liferay.portal.kernel.dao.orm.ExportActionableDynamicQuery
 		getExportActionableDynamicQuery(
 			com.liferay.exportimport.kernel.lar.PortletDataContext

--- a/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/service/persistence/AssetListEntryAssetEntryRelFinder.java
+++ b/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/service/persistence/AssetListEntryAssetEntryRelFinder.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.asset.list.service.persistence;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * @author Brian Wing Shun Chan
+ * @generated
+ */
+@ProviderType
+public interface AssetListEntryAssetEntryRelFinder {
+
+	public int countByA_S_Visible(long assetListEntryId, long segmentsEntryId);
+
+}

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/asset/entry/provider/AssetListAssetEntryProviderImpl.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/asset/entry/provider/AssetListAssetEntryProviderImpl.java
@@ -162,7 +162,7 @@ public class AssetListAssetEntryProviderImpl
 				AssetListEntryTypeConstants.TYPE_MANUAL)) {
 
 			return _assetListEntryAssetEntryRelLocalService.
-				getAssetListEntryAssetEntryRelsCount(
+				getAssetListEntryVisibleAssetEntryRelsCount(
 					assetListEntry.getAssetListEntryId(),
 					_getFirstSegmentsEntryId(assetListEntry, segmentsEntryIds));
 		}

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/service/base/AssetListEntryAssetEntryRelLocalServiceBaseImpl.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/service/base/AssetListEntryAssetEntryRelLocalServiceBaseImpl.java
@@ -16,6 +16,7 @@ package com.liferay.asset.list.service.base;
 
 import com.liferay.asset.list.model.AssetListEntryAssetEntryRel;
 import com.liferay.asset.list.service.AssetListEntryAssetEntryRelLocalService;
+import com.liferay.asset.list.service.persistence.AssetListEntryAssetEntryRelFinder;
 import com.liferay.asset.list.service.persistence.AssetListEntryAssetEntryRelPersistence;
 import com.liferay.exportimport.kernel.lar.ExportImportHelperUtil;
 import com.liferay.exportimport.kernel.lar.ManifestSummary;
@@ -601,6 +602,10 @@ public abstract class AssetListEntryAssetEntryRelLocalServiceBaseImpl
 	@Reference
 	protected AssetListEntryAssetEntryRelPersistence
 		assetListEntryAssetEntryRelPersistence;
+
+	@Reference
+	protected AssetListEntryAssetEntryRelFinder
+		assetListEntryAssetEntryRelFinder;
 
 	@Reference
 	protected com.liferay.counter.kernel.service.CounterLocalService

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/service/base/AssetListEntryLocalServiceBaseImpl.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/service/base/AssetListEntryLocalServiceBaseImpl.java
@@ -16,6 +16,7 @@ package com.liferay.asset.list.service.base;
 
 import com.liferay.asset.list.model.AssetListEntry;
 import com.liferay.asset.list.service.AssetListEntryLocalService;
+import com.liferay.asset.list.service.persistence.AssetListEntryAssetEntryRelFinder;
 import com.liferay.asset.list.service.persistence.AssetListEntryAssetEntryRelPersistence;
 import com.liferay.asset.list.service.persistence.AssetListEntryPersistence;
 import com.liferay.asset.list.service.persistence.AssetListEntrySegmentsEntryRelPersistence;
@@ -572,6 +573,10 @@ public abstract class AssetListEntryLocalServiceBaseImpl
 	@Reference
 	protected AssetListEntryAssetEntryRelPersistence
 		assetListEntryAssetEntryRelPersistence;
+
+	@Reference
+	protected AssetListEntryAssetEntryRelFinder
+		assetListEntryAssetEntryRelFinder;
 
 	@Reference
 	protected AssetListEntrySegmentsEntryRelPersistence

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/service/base/AssetListEntryServiceBaseImpl.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/service/base/AssetListEntryServiceBaseImpl.java
@@ -16,6 +16,7 @@ package com.liferay.asset.list.service.base;
 
 import com.liferay.asset.list.model.AssetListEntry;
 import com.liferay.asset.list.service.AssetListEntryService;
+import com.liferay.asset.list.service.persistence.AssetListEntryAssetEntryRelFinder;
 import com.liferay.asset.list.service.persistence.AssetListEntryAssetEntryRelPersistence;
 import com.liferay.asset.list.service.persistence.AssetListEntryPersistence;
 import com.liferay.asset.list.service.persistence.AssetListEntrySegmentsEntryRelPersistence;
@@ -134,6 +135,10 @@ public abstract class AssetListEntryServiceBaseImpl
 	@Reference
 	protected AssetListEntryAssetEntryRelPersistence
 		assetListEntryAssetEntryRelPersistence;
+
+	@Reference
+	protected AssetListEntryAssetEntryRelFinder
+		assetListEntryAssetEntryRelFinder;
 
 	@Reference
 	protected AssetListEntrySegmentsEntryRelPersistence

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/service/impl/AssetListEntryAssetEntryRelLocalServiceImpl.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/service/impl/AssetListEntryAssetEntryRelLocalServiceImpl.java
@@ -185,7 +185,9 @@ public class AssetListEntryAssetEntryRelLocalServiceImpl
 
 	public int getAssetListEntryVisibleAssetEntryRelsCount(
 		long assetLIstEntryId, long segmentsEntryId) {
-		return 0;
+
+		return assetListEntryAssetEntryRelFinder.countByA_S_Visible(
+			assetLIstEntryId, segmentsEntryId);
 	}
 
 	@Override

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/service/impl/AssetListEntryAssetEntryRelLocalServiceImpl.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/service/impl/AssetListEntryAssetEntryRelLocalServiceImpl.java
@@ -183,6 +183,11 @@ public class AssetListEntryAssetEntryRelLocalServiceImpl
 			assetListEntryId, segmentsEntryId);
 	}
 
+	public int getAssetListEntryVisibleAssetEntryRelsCount(
+		long assetLIstEntryId, long segmentsEntryId) {
+		return 0;
+	}
+
 	@Override
 	public AssetListEntryAssetEntryRel moveAssetListEntryAssetEntryRel(
 			long assetListEntryId, long segmentsEntryId, int position,

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/service/persistence/impl/AssetListEntryAssetEntryRelFinderBaseImpl.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/service/persistence/impl/AssetListEntryAssetEntryRelFinderBaseImpl.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.asset.list.service.persistence.impl;
+
+import com.liferay.asset.list.model.AssetListEntryAssetEntryRel;
+import com.liferay.asset.list.service.persistence.AssetListEntryAssetEntryRelPersistence;
+import com.liferay.asset.list.service.persistence.impl.constants.AssetListPersistenceConstants;
+import com.liferay.portal.kernel.configuration.Configuration;
+import com.liferay.portal.kernel.dao.orm.SessionFactory;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.service.persistence.impl.BasePersistenceImpl;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import javax.sql.DataSource;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Brian Wing Shun Chan
+ * @generated
+ */
+public abstract class AssetListEntryAssetEntryRelFinderBaseImpl
+	extends BasePersistenceImpl<AssetListEntryAssetEntryRel> {
+
+	public AssetListEntryAssetEntryRelFinderBaseImpl() {
+		setModelClass(AssetListEntryAssetEntryRel.class);
+
+		Map<String, String> dbColumnNames = new HashMap<String, String>();
+
+		dbColumnNames.put("uuid", "uuid_");
+
+		setDBColumnNames(dbColumnNames);
+	}
+
+	@Override
+	public Set<String> getBadColumnNames() {
+		return assetListEntryAssetEntryRelPersistence.getBadColumnNames();
+	}
+
+	@Override
+	@Reference(
+		target = AssetListPersistenceConstants.SERVICE_CONFIGURATION_FILTER,
+		unbind = "-"
+	)
+	public void setConfiguration(Configuration configuration) {
+		super.setConfiguration(configuration);
+	}
+
+	@Override
+	@Reference(
+		target = AssetListPersistenceConstants.ORIGIN_BUNDLE_SYMBOLIC_NAME_FILTER,
+		unbind = "-"
+	)
+	public void setDataSource(DataSource dataSource) {
+		super.setDataSource(dataSource);
+	}
+
+	@Override
+	@Reference(
+		target = AssetListPersistenceConstants.ORIGIN_BUNDLE_SYMBOLIC_NAME_FILTER,
+		unbind = "-"
+	)
+	public void setSessionFactory(SessionFactory sessionFactory) {
+		super.setSessionFactory(sessionFactory);
+	}
+
+	@Reference
+	protected AssetListEntryAssetEntryRelPersistence
+		assetListEntryAssetEntryRelPersistence;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		AssetListEntryAssetEntryRelFinderBaseImpl.class);
+
+	static {
+		try {
+			Class.forName(AssetListPersistenceConstants.class.getName());
+		}
+		catch (ClassNotFoundException classNotFoundException) {
+			throw new ExceptionInInitializerError(classNotFoundException);
+		}
+	}
+
+}

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/service/persistence/impl/AssetListEntryAssetEntryRelFinderImpl.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/service/persistence/impl/AssetListEntryAssetEntryRelFinderImpl.java
@@ -1,8 +1,73 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.asset.list.service.persistence.impl;
 
-public class AssetListEntryAssetEntryRelFinderImpl {
+import com.liferay.asset.list.service.persistence.AssetListEntryAssetEntryRelFinder;
+import com.liferay.portal.dao.orm.custom.sql.CustomSQL;
+import com.liferay.portal.kernel.dao.orm.QueryPos;
+import com.liferay.portal.kernel.dao.orm.SQLQuery;
+import com.liferay.portal.kernel.dao.orm.Session;
+import com.liferay.portal.kernel.dao.orm.Type;
+import com.liferay.portal.kernel.exception.SystemException;
 
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Javier de Arcos
+ */
+@Component(service = AssetListEntryAssetEntryRelFinder.class)
+public class AssetListEntryAssetEntryRelFinderImpl
+	extends AssetListEntryAssetEntryRelFinderBaseImpl
+	implements AssetListEntryAssetEntryRelFinder {
+
+	public static final String COUNT_BY_A_S_VISIBLE =
+		AssetListEntryAssetEntryRelFinder.class.getName() +
+			".countByA_S_Visible";
+
+	@Override
 	public int countByA_S_Visible(long assetListEntryId, long segmentsEntryId) {
-		return 0;
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			String sql = _customSQL.get(getClass(), COUNT_BY_A_S_VISIBLE);
+
+			SQLQuery q = session.createSynchronizedSQLQuery(sql);
+
+			q.addScalar(COUNT_COLUMN_NAME, Type.LONG);
+
+			QueryPos qPos = QueryPos.getInstance(q);
+
+			qPos.add(assetListEntryId);
+			qPos.add(segmentsEntryId);
+
+			Long count = (Long)q.uniqueResult();
+
+			return count.intValue();
+		}
+		catch (Exception exception) {
+			throw new SystemException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
 	}
+
+	@Reference
+	private CustomSQL _customSQL;
+
 }

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/service/persistence/impl/AssetListEntryAssetEntryRelFinderImpl.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/service/persistence/impl/AssetListEntryAssetEntryRelFinderImpl.java
@@ -1,0 +1,8 @@
+package com.liferay.asset.list.service.persistence.impl;
+
+public class AssetListEntryAssetEntryRelFinderImpl {
+
+	public int countByA_S_Visible(long assetListEntryId, long segmentsEntryId) {
+		return 0;
+	}
+}

--- a/modules/apps/asset/asset-list-service/src/main/resources/META-INF/custom-sql/default.xml
+++ b/modules/apps/asset/asset-list-service/src/main/resources/META-INF/custom-sql/default.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+
+<custom-sql>
+	<sql id="com.liferay.asset.list.service.persistence.AssetListEntryAssetEntryRelFinder.countByA_S_Visible">
+		<![CDATA[
+			SELECT
+				COUNT(*) AS COUNT_VALUE
+			FROM
+				AssetListEntryAssetEntryRel
+			INNER JOIN
+				AssetEntry ON
+					AssetListEntryAssetEntryRel.assetEntryId = AssetEntry.entryId
+			WHERE
+				(AssetListEntryAssetEntryRel.assetListEntryId = ?) AND
+				(AssetListEntryAssetEntryRel.segmentsEntryId = ?) AND
+				(AssetEntry.visible = 1)
+		]]>
+	</sql>
+</custom-sql>


### PR DESCRIPTION
When a element of a ContentSet is deleted, the number of elements in ContentSet does not change.

The issue was that the visible field in an AssetEntry is not being considered to count the number of elements. The method is modified to take this into consideration.