### PR TITLE
Upgrade url subject improvement

### DIFF
--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/upgrade/v3_1_0/UpgradeUrlSubject.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/upgrade/v3_1_0/UpgradeUrlSubject.java
@@ -61,17 +61,13 @@ public class UpgradeUrlSubject extends UpgradeProcess {
 
 			rs = ps.executeQuery();
 
-			if (!rs.next()) {
-				return urlSubject;
-			}
-
 			int mbMessageCount = rs.getInt(1);
 
 			if (mbMessageCount == 0) {
 				return urlSubject;
 			}
 
-			return null;
+			return urlSubject + StringPool.DASH + (mbMessageCount + 1);
 		}
 		finally {
 			DataAccess.cleanUp(ps);
@@ -138,11 +134,6 @@ public class UpgradeUrlSubject extends UpgradeProcess {
 		for (Map.Entry<Long, String> entry : urlSubjects.entrySet()) {
 			String uniqueUrlSubject = _findUniqueUrlSubject(
 				connection, entry.getValue());
-
-			for (int i = 1; uniqueUrlSubject == null; i++) {
-				uniqueUrlSubject = _findUniqueUrlSubject(
-					connection, entry.getValue() + StringPool.DASH + i);
-			}
 
 			_updateMBMessage(connection, entry.getKey(), uniqueUrlSubject);
 		}

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/upgrade/v3_1_0/UpgradeUrlSubject.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/upgrade/v3_1_0/UpgradeUrlSubject.java
@@ -67,7 +67,7 @@ public class UpgradeUrlSubject extends UpgradeProcess {
 				return urlSubject;
 			}
 
-			return urlSubject + StringPool.DASH + (mbMessageCount + 1);
+			return urlSubject + StringPool.DASH + mbMessageCount;
 		}
 		finally {
 			DataAccess.cleanUp(ps);


### PR DESCRIPTION
This should reduce the time the Upgrade is taking on a DB with lots of MBMessages that have multiple similar subjects (thus, generating lots of collisions when trying to `_findUniqueUrlSubject`)

The proposed solutions simply uses the messageCount on the first query, to append the number of already existing messages with that message to the generated URL.