### PR TITLE
LPS-106886 Add methods to LocaleUtil to get Locale from BCP47 languag…

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/util/LocaleUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/LocaleUtil.java
@@ -94,6 +94,16 @@ public class LocaleUtil {
 		return getInstance()._equals(locale1, locale2);
 	}
 
+	public static Locale fromBCP47LanguageId(String bcp47LanguageId) {
+		return getInstance()._fromBCP47LanguageId(bcp47LanguageId, true);
+	}
+
+	public static Locale fromBCP47LanguageId(
+		String bcp47LanguageId, boolean validate) {
+
+		return getInstance()._fromBCP47LanguageId(bcp47LanguageId, validate);
+	}
+
 	public static Locale fromLanguageId(String languageId) {
 		return getInstance()._fromLanguageId(languageId, true);
 	}
@@ -213,6 +223,22 @@ public class LocaleUtil {
 		String languageId2 = _toLanguageId(locale2);
 
 		return StringUtil.equalsIgnoreCase(languageId1, languageId2);
+	}
+
+	private Locale _fromBCP47LanguageId(
+		String bcp47LanguageId, boolean validate) {
+
+		if (bcp47LanguageId.equals("zh-Hans-CN")) {
+			return _fromLanguageId("zh_CN", validate);
+		}
+		else if (bcp47LanguageId.equals("zh-Hant-TW")) {
+			return _fromLanguageId("zh_TW", validate);
+		}
+
+		return _fromLanguageId(
+			StringUtil.replace(
+				bcp47LanguageId, CharPool.MINUS, CharPool.UNDERLINE),
+			validate);
 	}
 
 	private Locale _fromLanguageId(String languageId, boolean validate) {


### PR DESCRIPTION
…e id

As I continue working in localization I constantly repeating logic to get the Locale from a BCP47LanguageId.

This is missing from our LocaleUtil inside kernel package. We have only the other way around, get the BCP47LanguageId from a Locale.

Do you think it could be possible to add this logic inside our kernel package in LocaleUtil class? It seems the perfect fit to introduce this logic and we could benefit from it in the future

If not, where could I introduce this logic to avoid duplication? headless-common-spi package?