### PR TITLE
LPS-104321 Improved the FriendlyURL generation to avoid multi-DB queries

### DIFF
--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/upgrade/v3_1_0/UpgradeUrlSubject.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/upgrade/v3_1_0/UpgradeUrlSubject.java
@@ -61,9 +61,7 @@ public class UpgradeUrlSubject extends UpgradeProcess {
 
 			rs = ps.executeQuery();
 
-			if (!rs.next()) {
-				return urlSubject;
-			}
+			rs.first();
 
 			int mbMessageCount = rs.getInt(1);
 
@@ -71,7 +69,7 @@ public class UpgradeUrlSubject extends UpgradeProcess {
 				return urlSubject;
 			}
 
-			return null;
+			return urlSubject + StringPool.DASH + mbMessageCount;
 		}
 		finally {
 			DataAccess.cleanUp(ps);
@@ -138,11 +136,6 @@ public class UpgradeUrlSubject extends UpgradeProcess {
 		for (Map.Entry<Long, String> entry : urlSubjects.entrySet()) {
 			String uniqueUrlSubject = _findUniqueUrlSubject(
 				connection, entry.getValue());
-
-			for (int i = 1; uniqueUrlSubject == null; i++) {
-				uniqueUrlSubject = _findUniqueUrlSubject(
-					connection, entry.getValue() + StringPool.DASH + i);
-			}
 
 			_updateMBMessage(connection, entry.getKey(), uniqueUrlSubject);
 		}


### PR DESCRIPTION
Replaced the way that the uniqueURL was generated. Instead of iterating appending a different number until finding the first number that is not present at the db (which was producing a high number of queries when there is a lot of messages with the same title). 

In a big DB as the community forums, this was making that the upgrade process was taking more than 24h to execute (and it was not finished)

Now the URL is generated appending the a counter with a number based on the number of already existing `subjectUrl`s in the DB.

