### PR TITLE
LPS-107972 Reindex all test approach (WORK IN PROGRESS)

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyCategoryResourceTestCase.java
@@ -38,6 +38,8 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -66,6 +68,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -220,6 +223,8 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 			testGetTaxonomyCategoryRankedPage_addTaxonomyCategory(
 				randomTaxonomyCategory());
 
+		reindex(taxonomyCategory1.getId(), taxonomyCategory2.getId());
+
 		page = taxonomyCategoryResource.getTaxonomyCategoryRankedPage(
 			null, Pagination.of(1, 2));
 
@@ -252,6 +257,10 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		TaxonomyCategory taxonomyCategory3 =
 			testGetTaxonomyCategoryRankedPage_addTaxonomyCategory(
 				randomTaxonomyCategory());
+
+		reindex(
+			taxonomyCategory1.getId(), taxonomyCategory2.getId(),
+			taxonomyCategory3.getId());
 
 		Page<TaxonomyCategory> page1 =
 			taxonomyCategoryResource.getTaxonomyCategoryRankedPage(
@@ -316,6 +325,8 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 					irrelevantParentTaxonomyCategoryId,
 					randomIrrelevantTaxonomyCategory());
 
+			reindex(irrelevantTaxonomyCategory.getId());
+
 			page =
 				taxonomyCategoryResource.
 					getTaxonomyCategoryTaxonomyCategoriesPage(
@@ -337,6 +348,8 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		TaxonomyCategory taxonomyCategory2 =
 			testGetTaxonomyCategoryTaxonomyCategoriesPage_addTaxonomyCategory(
 				parentTaxonomyCategoryId, randomTaxonomyCategory());
+
+		reindex(taxonomyCategory1.getId(), taxonomyCategory2.getId());
 
 		page =
 			taxonomyCategoryResource.getTaxonomyCategoryTaxonomyCategoriesPage(
@@ -377,6 +390,8 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 			testGetTaxonomyCategoryTaxonomyCategoriesPage_addTaxonomyCategory(
 				parentTaxonomyCategoryId, taxonomyCategory1);
 
+		reindex(taxonomyCategory1.getId());
+
 		for (EntityField entityField : entityFields) {
 			Page<TaxonomyCategory> page =
 				taxonomyCategoryResource.
@@ -415,6 +430,8 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 			testGetTaxonomyCategoryTaxonomyCategoriesPage_addTaxonomyCategory(
 				parentTaxonomyCategoryId, randomTaxonomyCategory());
 
+		reindex(taxonomyCategory1.getId(), taxonomyCategory2.getId());
+
 		for (EntityField entityField : entityFields) {
 			Page<TaxonomyCategory> page =
 				taxonomyCategoryResource.
@@ -447,6 +464,10 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		TaxonomyCategory taxonomyCategory3 =
 			testGetTaxonomyCategoryTaxonomyCategoriesPage_addTaxonomyCategory(
 				parentTaxonomyCategoryId, randomTaxonomyCategory());
+
+		reindex(
+			taxonomyCategory1.getId(), taxonomyCategory2.getId(),
+			taxonomyCategory3.getId());
 
 		Page<TaxonomyCategory> page1 =
 			taxonomyCategoryResource.getTaxonomyCategoryTaxonomyCategoriesPage(
@@ -576,6 +597,8 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 			testGetTaxonomyCategoryTaxonomyCategoriesPage_addTaxonomyCategory(
 				parentTaxonomyCategoryId, taxonomyCategory2);
 
+		reindex(taxonomyCategory1.getId(), taxonomyCategory2.getId());
+
 		for (EntityField entityField : entityFields) {
 			Page<TaxonomyCategory> ascPage =
 				taxonomyCategoryResource.
@@ -652,10 +675,14 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		TaxonomyCategory taxonomyCategory =
 			testDeleteTaxonomyCategory_addTaxonomyCategory();
 
+		reindex(taxonomyCategory.getId());
+
 		assertHttpResponseStatusCode(
 			204,
 			taxonomyCategoryResource.deleteTaxonomyCategoryHttpResponse(
 				taxonomyCategory.getId()));
+
+		reindex(taxonomyCategory.getId());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -689,6 +716,8 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 							"\"" + taxonomyCategory.getId() + "\"");
 					}
 				}));
+
+		reindex(taxonomyCategory.getId());
 
 		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
 			invoke(graphQLField.toString()));
@@ -729,6 +758,8 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		TaxonomyCategory postTaxonomyCategory =
 			testGetTaxonomyCategory_addTaxonomyCategory();
 
+		reindex(postTaxonomyCategory.getId());
+
 		TaxonomyCategory getTaxonomyCategory =
 			taxonomyCategoryResource.getTaxonomyCategory(
 				postTaxonomyCategory.getId());
@@ -748,6 +779,8 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 	public void testGraphQLGetTaxonomyCategory() throws Exception {
 		TaxonomyCategory taxonomyCategory =
 			testGraphQLTaxonomyCategory_addTaxonomyCategory();
+
+		reindex(taxonomyCategory.getId());
 
 		List<GraphQLField> graphQLFields = getGraphQLFields();
 
@@ -792,6 +825,8 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 
 		_beanUtilsBean.copyProperties(
 			expectedPatchTaxonomyCategory, randomPatchTaxonomyCategory);
+
+		reindex(postTaxonomyCategory.getId());
 
 		TaxonomyCategory getTaxonomyCategory =
 			taxonomyCategoryResource.getTaxonomyCategory(
@@ -861,6 +896,8 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 					irrelevantTaxonomyVocabularyId,
 					randomIrrelevantTaxonomyCategory());
 
+			reindex(irrelevantTaxonomyCategory.getId());
+
 			page =
 				taxonomyCategoryResource.
 					getTaxonomyVocabularyTaxonomyCategoriesPage(
@@ -882,6 +919,8 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		TaxonomyCategory taxonomyCategory2 =
 			testGetTaxonomyVocabularyTaxonomyCategoriesPage_addTaxonomyCategory(
 				taxonomyVocabularyId, randomTaxonomyCategory());
+
+		reindex(taxonomyCategory1.getId(), taxonomyCategory2.getId());
 
 		page =
 			taxonomyCategoryResource.
@@ -923,6 +962,8 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 			testGetTaxonomyVocabularyTaxonomyCategoriesPage_addTaxonomyCategory(
 				taxonomyVocabularyId, taxonomyCategory1);
 
+		reindex(taxonomyCategory1.getId());
+
 		for (EntityField entityField : entityFields) {
 			Page<TaxonomyCategory> page =
 				taxonomyCategoryResource.
@@ -961,6 +1002,8 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 			testGetTaxonomyVocabularyTaxonomyCategoriesPage_addTaxonomyCategory(
 				taxonomyVocabularyId, randomTaxonomyCategory());
 
+		reindex(taxonomyCategory1.getId(), taxonomyCategory2.getId());
+
 		for (EntityField entityField : entityFields) {
 			Page<TaxonomyCategory> page =
 				taxonomyCategoryResource.
@@ -993,6 +1036,10 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		TaxonomyCategory taxonomyCategory3 =
 			testGetTaxonomyVocabularyTaxonomyCategoriesPage_addTaxonomyCategory(
 				taxonomyVocabularyId, randomTaxonomyCategory());
+
+		reindex(
+			taxonomyCategory1.getId(), taxonomyCategory2.getId(),
+			taxonomyCategory3.getId());
 
 		Page<TaxonomyCategory> page1 =
 			taxonomyCategoryResource.
@@ -1124,6 +1171,8 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 		taxonomyCategory2 =
 			testGetTaxonomyVocabularyTaxonomyCategoriesPage_addTaxonomyCategory(
 				taxonomyVocabularyId, taxonomyCategory2);
+
+		reindex(taxonomyCategory1.getId(), taxonomyCategory2.getId());
 
 		for (EntityField entityField : entityFields) {
 			Page<TaxonomyCategory> ascPage =
@@ -1987,6 +2036,26 @@ public abstract class BaseTaxonomyCategoryResourceTestCase {
 
 	protected TaxonomyCategory randomPatchTaxonomyCategory() throws Exception {
 		return randomTaxonomyCategory();
+	}
+
+	private void reindex(Object... ids) {
+		Set<Indexer<?>> indexers = IndexerRegistryUtil.getIndexers();
+		Stream<Indexer<?>> stream = indexers.stream();
+		stream.forEach(
+			indexer -> {
+				try {
+					indexer.reindex(
+						Arrays.stream(
+							ids
+						).map(
+							Object::toString
+						).toArray(
+							String[]::new
+						));
+				}
+				catch (Throwable e) {
+				}
+			});
 	}
 
 	protected TaxonomyCategoryResource taxonomyCategoryResource;

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/BaseTaxonomyVocabularyResourceTestCase.java
@@ -39,6 +39,8 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -67,6 +69,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -220,6 +223,8 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 				testGetSiteTaxonomyVocabulariesPage_addTaxonomyVocabulary(
 					irrelevantSiteId, randomIrrelevantTaxonomyVocabulary());
 
+			reindex(irrelevantTaxonomyVocabulary.getId());
+
 			page = taxonomyVocabularyResource.getSiteTaxonomyVocabulariesPage(
 				irrelevantSiteId, null, null, Pagination.of(1, 2), null);
 
@@ -238,6 +243,8 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		TaxonomyVocabulary taxonomyVocabulary2 =
 			testGetSiteTaxonomyVocabulariesPage_addTaxonomyVocabulary(
 				siteId, randomTaxonomyVocabulary());
+
+		reindex(taxonomyVocabulary1.getId(), taxonomyVocabulary2.getId());
 
 		page = taxonomyVocabularyResource.getSiteTaxonomyVocabulariesPage(
 			siteId, null, null, Pagination.of(1, 2), null);
@@ -275,6 +282,8 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 			testGetSiteTaxonomyVocabulariesPage_addTaxonomyVocabulary(
 				siteId, taxonomyVocabulary1);
 
+		reindex(taxonomyVocabulary1.getId());
+
 		for (EntityField entityField : entityFields) {
 			Page<TaxonomyVocabulary> page =
 				taxonomyVocabularyResource.getSiteTaxonomyVocabulariesPage(
@@ -311,6 +320,8 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 			testGetSiteTaxonomyVocabulariesPage_addTaxonomyVocabulary(
 				siteId, randomTaxonomyVocabulary());
 
+		reindex(taxonomyVocabulary1.getId(), taxonomyVocabulary2.getId());
+
 		for (EntityField entityField : entityFields) {
 			Page<TaxonomyVocabulary> page =
 				taxonomyVocabularyResource.getSiteTaxonomyVocabulariesPage(
@@ -341,6 +352,10 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		TaxonomyVocabulary taxonomyVocabulary3 =
 			testGetSiteTaxonomyVocabulariesPage_addTaxonomyVocabulary(
 				siteId, randomTaxonomyVocabulary());
+
+		reindex(
+			taxonomyVocabulary1.getId(), taxonomyVocabulary2.getId(),
+			taxonomyVocabulary3.getId());
 
 		Page<TaxonomyVocabulary> page1 =
 			taxonomyVocabularyResource.getSiteTaxonomyVocabulariesPage(
@@ -466,6 +481,8 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 			testGetSiteTaxonomyVocabulariesPage_addTaxonomyVocabulary(
 				siteId, taxonomyVocabulary2);
 
+		reindex(taxonomyVocabulary1.getId(), taxonomyVocabulary2.getId());
+
 		for (EntityField entityField : entityFields) {
 			Page<TaxonomyVocabulary> ascPage =
 				taxonomyVocabularyResource.getSiteTaxonomyVocabulariesPage(
@@ -550,6 +567,8 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		TaxonomyVocabulary taxonomyVocabulary2 =
 			testGraphQLTaxonomyVocabulary_addTaxonomyVocabulary();
 
+		reindex(taxonomyVocabulary1.getId(), taxonomyVocabulary2.getId());
+
 		jsonObject = JSONFactoryUtil.createJSONObject(
 			invoke(graphQLField.toString()));
 
@@ -611,10 +630,14 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		TaxonomyVocabulary taxonomyVocabulary =
 			testDeleteTaxonomyVocabulary_addTaxonomyVocabulary();
 
+		reindex(taxonomyVocabulary.getId());
+
 		assertHttpResponseStatusCode(
 			204,
 			taxonomyVocabularyResource.deleteTaxonomyVocabularyHttpResponse(
 				taxonomyVocabulary.getId()));
+
+		reindex(taxonomyVocabulary.getId());
 
 		assertHttpResponseStatusCode(
 			404,
@@ -648,6 +671,8 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 						put("taxonomyVocabularyId", taxonomyVocabulary.getId());
 					}
 				}));
+
+		reindex(taxonomyVocabulary.getId());
 
 		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
 			invoke(graphQLField.toString()));
@@ -689,6 +714,8 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		TaxonomyVocabulary postTaxonomyVocabulary =
 			testGetTaxonomyVocabulary_addTaxonomyVocabulary();
 
+		reindex(postTaxonomyVocabulary.getId());
+
 		TaxonomyVocabulary getTaxonomyVocabulary =
 			taxonomyVocabularyResource.getTaxonomyVocabulary(
 				postTaxonomyVocabulary.getId());
@@ -709,6 +736,8 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 	public void testGraphQLGetTaxonomyVocabulary() throws Exception {
 		TaxonomyVocabulary taxonomyVocabulary =
 			testGraphQLTaxonomyVocabulary_addTaxonomyVocabulary();
+
+		reindex(taxonomyVocabulary.getId());
 
 		List<GraphQLField> graphQLFields = getGraphQLFields();
 
@@ -751,6 +780,8 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 
 		_beanUtilsBean.copyProperties(
 			expectedPatchTaxonomyVocabulary, randomPatchTaxonomyVocabulary);
+
+		reindex(postTaxonomyVocabulary.getId());
 
 		TaxonomyVocabulary getTaxonomyVocabulary =
 			taxonomyVocabularyResource.getTaxonomyVocabulary(
@@ -1644,6 +1675,26 @@ public abstract class BaseTaxonomyVocabularyResourceTestCase {
 		throws Exception {
 
 		return randomTaxonomyVocabulary();
+	}
+
+	private void reindex(Object... ids) {
+		Set<Indexer<?>> indexers = IndexerRegistryUtil.getIndexers();
+		Stream<Indexer<?>> stream = indexers.stream();
+		stream.forEach(
+			indexer -> {
+				try {
+					indexer.reindex(
+						Arrays.stream(
+							ids
+						).map(
+							Object::toString
+						).toArray(
+							String[]::new
+						));
+				}
+				catch (Throwable e) {
+				}
+			});
 	}
 
 	protected TaxonomyVocabularyResource taxonomyVocabularyResource;

--- a/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
+++ b/modules/util/portal-tools-rest-builder/src/main/resources/com/liferay/portal/tools/rest/builder/dependencies/base_resource_test_case.ftl
@@ -33,6 +33,8 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
@@ -65,6 +67,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -222,6 +225,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 					@SuppressWarnings("PMD.UnusedLocalVariable")
 					${schemaName} ${schemaVarName} = test${javaMethodSignature.methodName?cap_first}_add${schemaName}();
 
+					reindex(${schemaVarName}.getId());
+
 					assertHttpResponseStatusCode(204, ${schemaVarName}Resource.${javaMethodSignature.methodName}HttpResponse(
 
 					<#list javaMethodSignature.javaMethodParameters as javaMethodParameter>
@@ -243,6 +248,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 					</#list>
 
 					));
+
+					reindex(${schemaVarName}.getId());
 
 					<#if freeMarkerTool.hasJavaMethodSignature(javaMethodSignatures, "get" + javaMethodSignature.methodName?remove_beginning("delete"))>
 						assertHttpResponseStatusCode(404, ${schemaVarName}Resource.get${javaMethodSignature.methodName?remove_beginning("delete")}HttpResponse(
@@ -374,6 +381,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 
 							randomIrrelevant${schemaName}());
 
+							reindex(irrelevant${schemaName}.getId());
+
 							page = ${schemaVarName}Resource.${javaMethodSignature.methodName}(
 
 							<#list javaMethodSignature.javaMethodParameters as javaMethodParameter>
@@ -414,6 +423,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 					</#list>
 
 					random${schemaName}());
+
+					reindex(${schemaVarName}1.getId(), ${schemaVarName}2.getId());
 
 					page = ${schemaVarName}Resource.${javaMethodSignature.methodName}(
 
@@ -488,6 +499,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 
 						${schemaVarName}1);
 
+						reindex(${schemaVarName}1.getId());
+
 						for (EntityField entityField : entityFields) {
 							Page<${schemaName}> page = ${schemaVarName}Resource.${javaMethodSignature.methodName}(
 
@@ -541,6 +554,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 						</#list>
 
 						random${schemaName}());
+
+						reindex(${schemaVarName}1.getId(), ${schemaVarName}2.getId());
 
 						for (EntityField entityField : entityFields) {
 							Page<${schemaName}> page = ${schemaVarName}Resource.${javaMethodSignature.methodName}(
@@ -598,6 +613,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 						</#list>
 
 						random${schemaName}());
+
+						reindex(${schemaVarName}1.getId(), ${schemaVarName}2.getId(), ${schemaVarName}3.getId());
 
 						Page<${schemaName}> page1 = ${schemaVarName}Resource.${javaMethodSignature.methodName}(
 
@@ -744,6 +761,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 
 						${schemaVarName}2);
 
+						reindex(${schemaVarName}1.getId(), ${schemaVarName}2.getId());
+
 						for (EntityField entityField : entityFields) {
 							Page<${schemaName}> ascPage = ${schemaVarName}Resource.${javaMethodSignature.methodName}(
 
@@ -847,6 +866,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 				<#if properties?keys?seq_contains("id")>
 					${schemaName} post${schemaName} = test${javaMethodSignature.methodName?cap_first}_add${schemaName}();
 
+					reindex(post${schemaName}.getId());
+
 					${schemaName} get${schemaName} = ${schemaVarName}Resource.${javaMethodSignature.methodName}(
 
 					<#list javaMethodSignature.javaMethodParameters as javaMethodParameter>
@@ -924,6 +945,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 					${schemaName} expectedPatch${schemaName} = post${schemaName}.clone();
 
 					_beanUtilsBean.copyProperties(expectedPatch${schemaName}, randomPatch${schemaName});
+
+					reindex(post${schemaName}.getId());
 
 					${schemaName} get${schemaName} = ${schemaVarName}Resource.get${schemaName}(patch${schemaName}.getId());
 
@@ -1092,6 +1115,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 				@SuppressWarnings("PMD.UnusedLocalVariable")
 				${schemaName} ${schemaVarName} = test${javaMethodSignature.methodName?cap_first}_add${schemaName}();
 
+				reindex(${schemaVarName}.getId());
+
 				assertHttpResponseStatusCode(
 					204,
 					${schemaVarName}Resource.${javaMethodSignature.methodName}HttpResponse(
@@ -1119,6 +1144,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 							<#sep>, </#sep>
 						</#list>
 					));
+
+				reindex(${schemaVarName}.getId());
 
 				assertHttpResponseStatusCode(
 					404,
@@ -1206,6 +1233,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 								}
 							}));
 
+					reindex(${schemaVarName}.getId());
+
 					JSONObject jsonObject = JSONFactoryUtil.createJSONObject(invoke(graphQLField.toString()));
 
 					JSONObject dataJSONObject = jsonObject.getJSONObject("data");
@@ -1284,6 +1313,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 					${schemaName} ${schemaVarName}1 = testGraphQL${schemaName}_add${schemaName}();
 					${schemaName} ${schemaVarName}2 = testGraphQL${schemaName}_add${schemaName}();
 
+					reindex(${schemaVarName}1.getId(), ${schemaVarName}2.getId());
+
 					jsonObject = JSONFactoryUtil.createJSONObject(invoke(graphQLField.toString()));
 
 					dataJSONObject = jsonObject.getJSONObject("data");
@@ -1300,6 +1331,8 @@ public abstract class Base${schemaName}ResourceTestCase {
 			public void testGraphQL${javaMethodSignature.methodName?cap_first}() throws Exception {
 				<#if properties?keys?seq_contains("id")>
 					${schemaName} ${schemaVarName} = testGraphQL${schemaName}_add${schemaName}();
+
+					reindex(${schemaVarName}.getId());
 
 					List<GraphQLField> graphQLFields = getGraphQLFields();
 
@@ -1364,6 +1397,9 @@ public abstract class Base${schemaName}ResourceTestCase {
 					${schemaName} post${schemaName} = testGet${schemaName}_add${schemaName}();
 
 					${relatedSchemaName} post${relatedSchemaName} = test${javaMethodSignature.methodName?cap_first}_add${relatedSchemaName}(post${schemaName}.getId(), random${relatedSchemaName}());
+
+					reindex(post${schemaName}.getId());
+					reindex(post${relatedSchemaName}.getId());
 
 					${relatedSchemaName} get${relatedSchemaName} = ${schemaVarName}Resource.${javaMethodSignature.methodName}(post${schemaName}.getId());
 
@@ -1974,6 +2010,18 @@ public abstract class Base${schemaName}ResourceTestCase {
 			};
 		}
 	</#list>
+
+	private void reindex(Object ... ids) {
+		Set<Indexer<?>> indexers = IndexerRegistryUtil.getIndexers();
+		Stream<Indexer<?>> stream = indexers.stream();
+		stream.forEach(indexer -> {
+			try {
+				indexer.reindex(
+					Arrays.stream(ids).map(Object::toString).toArray(String[]::new));
+			}
+			catch (Throwable e) { }
+		});
+	}
 
 	protected ${schemaName}Resource ${schemaVarName}Resource;
 	protected Group irrelevantGroup;


### PR DESCRIPTION
Testing the approach of reindexing all in ES every time an item is modified and then a get method is used to make some assertions about the result (to work with updated data).

This approach is not tied with the resource inner representation class but is less efficient and uglier. Also relies on the fact that the resource must have a getId method, to tell the indexer which id to reindex.

We should review if there are some other cases where the reindex is needed, or if there are some extra reindex actions.

Not a big fan of this solution. Theoretically speaking, as this tests are in the integration layer, is correct that they fail when ES is overcharged, and the solution should be made in the CI infraestructure to ensure the ES quality or in the production code.

Other option may be changing the integration test approach to avoid this "_addResource"and "getResource" chains to assert that the code is working (although I'm aware that this is the natural approach). Following this line of thought, it is possible to create entities in the tests without making a POST request? Or that these entities are pre-provisioned?